### PR TITLE
feat: Add Session Data for internal experiments

### DIFF
--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -67,7 +67,8 @@ muxDistribution {
 
 dependencies {
   api "com.mux.stats.sdk.muxstats:data-media3-custom:$project.version"
-  api 'androidx.media3:media3-exoplayer:1.0.2' // TODO: Just base and hls
+  api 'androidx.media3:media3-exoplayer:1.0.2' // TODO: Just base and hls (or do I have base now?)
+  api 'androidx.media3:media3-exoplayer-hls:1.0.2'
   // implementation is used so it doesn't pollute customers namespace
   implementation "com.mux:utils-kt:$coreVersion"
 

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -67,10 +67,11 @@ muxDistribution {
 
 dependencies {
   api "com.mux.stats.sdk.muxstats:data-media3-custom:$project.version"
-  api 'androidx.media3:media3-exoplayer:1.0.2' // TODO: Just base and hls (or do I have base now?)
-  api 'androidx.media3:media3-exoplayer-hls:1.0.2'
   // implementation is used so it doesn't pollute customers namespace
   implementation "com.mux:utils-kt:$coreVersion"
+
+  api "androidx.media3:media3-exoplayer:$media3Version" // TODO: Not all of exo is required
+  compileOnly "androidx.media3:media3-exoplayer-hls:$media3Version"
 
   implementation 'androidx.core:core-ktx:1.10.1'
   implementation 'androidx.appcompat:appcompat:1.6.1'

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
@@ -12,19 +12,28 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.exoplayer.source.MediaLoadData
 import com.mux.android.util.weak
+import com.mux.stats.sdk.muxstats.internal.createExoSessionDataBinding
 
 class ExoPlayerBinding : MuxPlayerAdapter.PlayerBinding<ExoPlayer> {
+
+  private val sessionDataBinding = createExoSessionDataBinding()
 
   private var listener: MuxAnalyticsListener? = null
 
   override fun bindPlayer(player: ExoPlayer, collector: MuxStateCollector) {
     listener = MuxAnalyticsListener(player, collector).also { player.addAnalyticsListener(it) }
+
+    // Also delegate to sub-bindings
+    sessionDataBinding.bindPlayer(player, collector)
   }
 
   override fun unbindPlayer(player: ExoPlayer, collector: MuxStateCollector) {
     listener?.let { player.removeAnalyticsListener(it) }
     collector.playerWatcher?.stop("player unbound")
     listener = null
+
+    // Also delegate to sub-bindings
+    sessionDataBinding.unbindPlayer(player, collector)
   }
 }
 

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/PlayerExt.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/PlayerExt.kt
@@ -44,7 +44,8 @@ fun Player.monitorWithMuxData(
       customerData = customerData,
       player = this,
       playerView = playerView,
-      customOptions = customOptions
+      customOptions = customOptions,
+      playerBinding = BaseMedia3Binding()
     )
   }
 }

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/internal/SessionDataBindings.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/internal/SessionDataBindings.kt
@@ -1,0 +1,101 @@
+package com.mux.stats.sdk.muxstats.internal
+
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.analytics.AnalyticsListener
+import androidx.media3.exoplayer.hls.HlsManifest
+import com.mux.android.util.weak
+import com.mux.stats.sdk.core.model.SessionTag
+import com.mux.stats.sdk.core.util.MuxLogger
+import com.mux.stats.sdk.muxstats.MuxPlayerAdapter
+import com.mux.stats.sdk.muxstats.MuxStateCollector
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+private class SessionDataPlayerBinding : MuxPlayerAdapter.PlayerBinding<ExoPlayer> {
+
+  private var listener: AnalyticsListener? by weak(null)
+
+  override fun bindPlayer(player: ExoPlayer, collector: MuxStateCollector) {
+    if (isHlsExtensionAvailable()) {
+      listener = SessionDataListener(player, collector).also { player.addAnalyticsListener(it) }
+    }
+  }
+
+  override fun unbindPlayer(player: ExoPlayer, collector: MuxStateCollector) {
+    listener?.let { player.removeAnalyticsListener(it) }
+  }
+
+  /**
+   * Listens for timeline changes and updates HLS session data if we're on an HLS stream.
+   * This class should only be instantiated if ExoPlayer's HLS extension is available at runtime
+   * @see [.isHlsExtensionAvailable]
+   */
+  @OptIn(UnstableApi::class)
+  private class SessionDataListener(player: ExoPlayer, val collector: MuxStateCollector) :
+    AnalyticsListener {
+
+    private val player by weak(player)
+
+    companion object {
+      val RX_SESSION_TAG_DATA_ID: Pattern by lazy { Pattern.compile("DATA-ID=\"(.*)\",") }
+      val RX_SESSION_TAG_VALUES: Pattern by lazy { Pattern.compile("VALUE=\"(.*)\"") }
+
+      /** HLS session data tags with this Data ID will be sent to Mux Data  */
+      const val HLS_SESSION_LITIX_PREFIX = "io.litix.data."
+      const val LOG_TAG = "SessionDataListener"
+    }
+
+    override fun onTimelineChanged(eventTime: AnalyticsListener.EventTime, reason: Int) {
+      player?.let { safePlayer ->
+        val manifest = safePlayer.currentManifest
+        if (manifest is HlsManifest) {
+          collector.onMainPlaylistTags(parseHlsSessionData(manifest.multivariantPlaylist.tags))
+        }
+      }
+    }
+
+    private fun parseHlsSessionData(hlsTags: List<String>): List<SessionTag> {
+      val data: MutableList<SessionTag> = ArrayList()
+      for (tag in filterHlsSessionTags(hlsTags)) {
+        val st: SessionTag = parseHlsSessionTag(tag)
+        if (st.key != null && st.key.contains(HLS_SESSION_LITIX_PREFIX)) {
+          data.add(parseHlsSessionTag(tag))
+        }
+      }
+      return data
+    }
+
+    private fun filterHlsSessionTags(rawTags: List<String>) =
+      rawTags.filter { it.substring(1).startsWith("EXT-X-SESSION-DATA") }
+
+    private fun parseHlsSessionTag(line: String): SessionTag {
+      val dataId: Matcher = RX_SESSION_TAG_DATA_ID.matcher(line)
+      val value: Matcher = RX_SESSION_TAG_VALUES.matcher(line)
+      var parsedDataId: String? = ""
+      var parsedValue: String? = ""
+      if (dataId.find()) {
+        parsedDataId = dataId.group(1)?.replace(HLS_SESSION_LITIX_PREFIX, "")
+      } else {
+        MuxLogger.d(LOG_TAG, "Data-ID not found in session data: $line")
+      }
+      if (value.find()) {
+        parsedValue = value.group(1)
+      } else {
+        MuxLogger.d(LOG_TAG, "Value not found in session data: $line")
+      }
+      return SessionTag(parsedDataId, parsedValue)
+    }
+  }
+}
+
+/**
+ * Creates a listener that listens for timeline changes and updates HLS session data if we're on an
+ * HLS stream.
+ * This class should only be instantiated if ExoPlayer's HLS extension is available at runtime
+ * @see [.isHlsExtensionAvailable]
+ */
+@JvmSynthetic
+internal fun createExoSessionDataBinding(): MuxPlayerAdapter.PlayerBinding<ExoPlayer> =
+  SessionDataPlayerBinding()

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/internal/SessionDataBindings.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/internal/SessionDataBindings.kt
@@ -57,14 +57,9 @@ private class SessionDataPlayerBinding : MuxPlayerAdapter.PlayerBinding<ExoPlaye
     }
 
     private fun parseHlsSessionData(hlsTags: List<String>): List<SessionTag> {
-      val data: MutableList<SessionTag> = ArrayList()
-      for (tag in filterHlsSessionTags(hlsTags)) {
-        val st: SessionTag = parseHlsSessionTag(tag)
-        if (st.key != null && st.key.contains(HLS_SESSION_LITIX_PREFIX)) {
-          data.add(parseHlsSessionTag(tag))
-        }
-      }
-      return data
+      return filterHlsSessionTags(hlsTags)
+        .map { parseHlsSessionTag(it) }
+        .filter { it.key != null && it.key.contains(HLS_SESSION_LITIX_PREFIX) }
     }
 
     private fun filterHlsSessionTags(rawTags: List<String>) =

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/internal/Utils.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/internal/Utils.kt
@@ -1,0 +1,21 @@
+package com.mux.stats.sdk.muxstats.internal
+
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.hls.HlsManifest
+import com.mux.stats.sdk.core.util.MuxLogger
+
+// lazily-cached check for the HLS extension, which may not be available at runtime
+@OptIn(UnstableApi::class) // opting-in to HlsManifest
+private val hlsExtensionAvailable: Boolean by lazy {
+  try {
+    Class.forName(HlsManifest::class.java.canonicalName!!)
+    true
+  } catch (e: ClassNotFoundException) {
+    MuxLogger.w("isHlsExtensionAvailable", "HLS extension not found. Some features may not work")
+    false
+  }
+}
+
+@JvmSynthetic
+internal fun isHlsExtensionAvailable() = hlsExtensionAvailable

--- a/library/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsSdkMedia3.kt
+++ b/library/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsSdkMedia3.kt
@@ -27,8 +27,8 @@ class MuxStatsSdkMedia3<P : Player> @JvmOverloads constructor(
   customerData: CustomerData,
   player: P,
   playerView: View? = null,
-  playerBinding: MuxPlayerAdapter.PlayerBinding<P> = BaseMedia3Binding(),
   customOptions: CustomOptions? = null,
+  playerBinding: MuxPlayerAdapter.PlayerBinding<P>,
 ) : MuxDataSdk<P, View>(
   context = context,
   envKey = envKey,


### PR DESCRIPTION
This also includes a minor API change (not breaking) that removes a default parameter. The idea is that if someone is using a custom player, they are sophisticated enough to inject the right `PlayerBinding`. This will be discussed briefly in the dev guide, though I doubt we'll be seeing a lot of people doing it.