### PR TITLE
fix: Declare dependencies on in-project libs after evaluate

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,9 +36,11 @@ android {
 }
 
 dependencies {
-  implementation "com.mux.stats.sdk.muxstats:data-media3-ima:${project.version}"
-  implementation "com.mux.stats.sdk.muxstats:data-media3-custom:${project.version}"
-  implementation "com.mux.stats.sdk.muxstats:data-media3:${project.version}"
+  afterEvaluate {
+    implementation "com.mux.stats.sdk.muxstats:data-media3-ima:${project.version}"
+    implementation "com.mux.stats.sdk.muxstats:data-media3-custom:${project.version}"
+    implementation "com.mux.stats.sdk.muxstats:data-media3:${project.version}"
+  }
 
   implementation "androidx.media3:media3-exoplayer:${media3Version}"
   implementation "androidx.media3:media3-exoplayer-dash:${media3Version}"

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -66,7 +66,10 @@ muxDistribution {
 }
 
 dependencies {
-  api "com.mux.stats.sdk.muxstats:data-media3-custom:$project.version"
+  afterEvaluate {
+    // The version won't be available when `dependencies` is evaluated
+    api "com.mux.stats.sdk.muxstats:data-media3-custom:$project.version"
+  }
   // implementation is used so it doesn't pollute customers namespace
   implementation "com.mux:utils-kt:$coreVersion"
 

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -66,7 +66,10 @@ muxDistribution {
 }
 
 dependencies {
-  api "com.mux.stats.sdk.muxstats:data-media3-custom:$project.version"
+  afterEvaluate {
+    api "com.mux.stats.sdk.muxstats:data-media3-custom:$project.version"
+  }
+  
   // note- 3.30.0 and 3.30.1 are marked as broken by google, so don't use
   api 'com.google.ads.interactivemedia.v3:interactivemedia:3.29.0'
   implementation "androidx.media3:media3-exoplayer-ima:${media3Version}"


### PR DESCRIPTION
Fixes #18.

We have to do this because the `muxDistribution` block is resolved after the `dependencies` block. The distribution plugin (configured by `muxDistribution`) is what automatically sets the version, so we need to declare dependencies that involve our current version (specifically dependencies on other modules in this project) `afterEvaluate`.