### PR TITLE
fix: ImaAdsSdkListener.create should not be hidden from java

### DIFF
--- a/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/MuxImaAdsListener.kt
+++ b/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/MuxImaAdsListener.kt
@@ -182,7 +182,7 @@ class MuxImaAdsListener private constructor(
     /**
      * Creates a new [MuxImaAdsListener] based on the given [MuxStatsSdkMedia3]
      */
-    @JvmSynthetic
+    @JvmStatic
     fun newListener(
       muxSdk: MuxStatsSdkMedia3<*>,
       customerAdEventListener: AdEventListener = AdEventListener { },


### PR DESCRIPTION
This shouldn't be hidden from Java, I just did the wrong annotation. `@JvmStatic` allows java callers to access the method as `MuxImaAdsListener.create()`