### PR TITLE
maint: Add support for media3 v1.1.x

### DIFF
--- a/.github/workflows/android-cicd.yml
+++ b/.github/workflows/android-cicd.yml
@@ -32,7 +32,7 @@ jobs:
           ORG_GRADLE_PROJECT_artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
           GH_USER: ${{ github.actor }}
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and Publish to Dev Repo [Common]
+      - name: Build and Publish to Dev Repo [Exo/IMA]
         uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: :library-ima:artifactoryPublish :library-exo:artifactoryPublish

--- a/.github/workflows/android-cicd.yml
+++ b/.github/workflows/android-cicd.yml
@@ -23,10 +23,19 @@ jobs:
           distribution: 'temurin'
       # This step will build all modules configured for publication and publish them
       # Does your project publish multiple libraries in a dependency chain? You'll have to add another copy of this step and build the dependency in the first one
-      - name: Build and Publish to Dev Repo
+      - name: Build and Publish to Dev Repo [Base]
         uses: gradle/gradle-build-action@v2.4.2
         with:
-          arguments: artifactoryPublish
+          arguments: :library:artifactoryPublish
+        env:
+          ORG_GRADLE_PROJECT_artifactory_user: ${{ secrets.ARTIFACTORY_EMAIL }}
+          ORG_GRADLE_PROJECT_artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          GH_USER: ${{ github.actor }}
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and Publish to Dev Repo [Common]
+        uses: gradle/gradle-build-action@v2.4.2
+        with:
+          arguments: :library-ima:artifactoryPublish :library-exo:artifactoryPublish
         env:
           ORG_GRADLE_PROJECT_artifactory_user: ${{ secrets.ARTIFACTORY_EMAIL }}
           ORG_GRADLE_PROJECT_artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}

--- a/.github/workflows/artifactory-deploy-from-tag.yml
+++ b/.github/workflows/artifactory-deploy-from-tag.yml
@@ -25,10 +25,21 @@ jobs:
           distribution: 'temurin'
       # This step will build all modules configured for publication and publish them
       # Does your project publish multiple libraries in a dependency chain? You'll have to add another copy of this step and build the dependency in the first one
-      - name: Deploy to Release Repo
+      - name: Build and Publish to Dev Repo [Base]
         uses: gradle/gradle-build-action@v2.4.2
         with:
-          arguments: artifactoryPublish
+          arguments: :library:artifactoryPublish
         env:
           ORG_GRADLE_PROJECT_artifactory_user: ${{ secrets.ARTIFACTORY_EMAIL }}
           ORG_GRADLE_PROJECT_artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          GH_USER: ${{ github.actor }}
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and Publish to Dev Repo [Common]
+        uses: gradle/gradle-build-action@v2.4.2
+        with:
+          arguments: :library-ima:artifactoryPublish :library-exo:artifactoryPublish
+        env:
+          ORG_GRADLE_PROJECT_artifactory_user: ${{ secrets.ARTIFACTORY_EMAIL }}
+          ORG_GRADLE_PROJECT_artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          GH_USER: ${{ github.actor }}
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,20 +45,6 @@ android {
 }
 
 dependencies {
-  afterEvaluate {
-//    println ">>>> VERSION IS $project.version"
-//    project.version = "dev-maint-media3-1_1-a1a44b0"
-//    at_1_0Implementation "com.mux.stats.sdk.muxstats:data-media3-ima-at_1_0:$project.version"
-//    at_1_1Implementation "com.mux.stats.sdk.muxstats:data-media3-ima-at_1_1:$project.version"
-//    latestImplementation "com.mux.stats.sdk.muxstats:data-media3-ima:$project.version"
-//    at_1_0Implementation "com.mux.stats.sdk.muxstats:data-media3-at_1_0:$project.version"
-//    at_1_1Implementation "com.mux.stats.sdk.muxstats:data-media3-at_1_1:$project.version"
-//    latestImplementation "com.mux.stats.sdk.muxstats:data-media3-$project.version"
-
-//    implementation "com.mux.stats.sdk.muxstats:data-media3-ima:${project.version}"
-//    implementation "com.mux.stats.sdk.muxstats:data-media3:${project.version}"
-  }
-
   implementation project(":library-ima")
   implementation project(":library-exo")
   implementation project(":library")
@@ -102,29 +88,3 @@ dependencies {
   androidTestImplementation 'androidx.test.ext:junit:1.1.5'
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }
-
-configurations.configureEach {
-  resolutionStrategy.dependencySubstitution {
-    android.applicationVariants.each { variant ->
-      def media3variant = variant.productFlavors.find { it.dimension == "media3" }.name
-      def suffix = {
-        if (media3variant.containsIgnoreCase("latest")) {
-          return ""
-        } else {
-          return "-$media3variant"
-        }
-      }
-      substitute module("com.mux.stats.sdk.muxstats:data-media3-custom${suffix()}")\
-        using project(":library")\
-        because "in development, we build from src"
-      substitute module("com.mux.stats.sdk.muxstats:data-media3${suffix()}") using\
-        project(":library-exo")\
-        because "in development, we build from src"
-      substitute module("com.mux.stats.sdk.muxstats:data-media3-ima${suffix()}") using\
-        project(":library-ima")\
-        because "in development, we build from src"
-
-      }
-  }
-}
-

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,18 +46,21 @@ android {
 
 dependencies {
   afterEvaluate {
-    println ">>>> VERSION IS $project.version"
-    at_1_0Api "com.mux.stats.sdk.muxstats:data-media3-ima-at_1_0:$project.version"
-    at_1_1Api "com.mux.stats.sdk.muxstats:data-media3-ima-at_1_1:$project.version"
-    latestApi "com.mux.stats.sdk.muxstats:data-media3-ima:$project.version"
-    at_1_0Api "com.mux.stats.sdk.muxstats:data-media3-at_1_0:$project.version"
-    at_1_1Api "com.mux.stats.sdk.muxstats:data-media3-at_1_1:$project.version"
-    latestApi "com.mux.stats.sdk.muxstats:data-media3-$project.version"
-
+//    println ">>>> VERSION IS $project.version"
+//    at_1_0Api "com.mux.stats.sdk.muxstats:data-media3-ima-at_1_0:$project.version"
+//    at_1_1Api "com.mux.stats.sdk.muxstats:data-media3-ima-at_1_1:$project.version"
+//    latestApi "com.mux.stats.sdk.muxstats:data-media3-ima:$project.version"
+//    at_1_0Api "com.mux.stats.sdk.muxstats:data-media3-at_1_0:$project.version"
+//    at_1_1Api "com.mux.stats.sdk.muxstats:data-media3-at_1_1:$project.version"
+//    latestApi "com.mux.stats.sdk.muxstats:data-media3-$project.version"
 
 //    implementation "com.mux.stats.sdk.muxstats:data-media3-ima:${project.version}"
 //    implementation "com.mux.stats.sdk.muxstats:data-media3:${project.version}"
   }
+
+  implementation project(":library-ima")
+  implementation project(":library-exo")
+  implementation project(":library")
 
   //noinspection GradleDependency
   at_1_0Implementation "androidx.media3:media3-exoplayer:1.0.0"
@@ -99,28 +102,28 @@ dependencies {
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }
 
-configurations.all {
-  resolutionStrategy.dependencySubstitution {
-    android.applicationVariants.each { variant ->
-      def media3Variant = variant.productFlavors.find { it.dimension == "media3" }.name
-      def suffix = {
-        if (media3Variant.containsIgnoreCase("latest")) {
-          return ""
-        } else {
-          return "-$media3Variant"
-        }
-      }
-      substitute module("com.mux.stats.sdk.muxstats:data-media3-custom${suffix()}")\
-        using project(":library")\
-        because "In development, we build from src"
-      substitute module("com.mux.stats.sdk.muxstats:data-media3${suffix()}") using \
-        project(":library-exo")\
-        because "In development, we build from src"
-      substitute module("com.mux.stats.sdk.muxstats:data-media3-ima${suffix()}") using \
-        project(":library-ima")\
-        because "In development, we build from src"
-
-      }
-  }
-}
+//configurations.all {
+//  resolutionStrategy.dependencySubstitution {
+//    android.applicationVariants.each { variant ->
+//      def media3Variant = variant.productFlavors.find { it.dimension == "media3" }.name
+//      def suffix = {
+//        if (media3Variant.containsIgnoreCase("latest")) {
+//          return ""
+//        } else {
+//          return "-$media3Variant"
+//        }
+//      }
+//      substitute module("com.mux.stats.sdk.muxstats:data-media3-custom${suffix()}")\
+//        using project(":library")\
+//        because "In development, we build from src"
+//      substitute module("com.mux.stats.sdk.muxstats:data-media3${suffix()}") using \
+//        project(":library-exo")\
+//        because "In development, we build from src"
+//      substitute module("com.mux.stats.sdk.muxstats:data-media3-ima${suffix()}") using \
+//        project(":library-ima")\
+//        because "In development, we build from src"
+//
+//      }
+//  }
+//}
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,21 +47,21 @@ android {
 dependencies {
   afterEvaluate {
 //    println ">>>> VERSION IS $project.version"
-    project.version = "dev-maint-media3-1_1-a1a44b0"
-    at_1_0Api "com.mux.stats.sdk.muxstats:data-media3-ima-at_1_0:$project.version"
-    at_1_1Api "com.mux.stats.sdk.muxstats:data-media3-ima-at_1_1:$project.version"
-    latestApi "com.mux.stats.sdk.muxstats:data-media3-ima:$project.version"
-    at_1_0Api "com.mux.stats.sdk.muxstats:data-media3-at_1_0:$project.version"
-    at_1_1Api "com.mux.stats.sdk.muxstats:data-media3-at_1_1:$project.version"
-    latestApi "com.mux.stats.sdk.muxstats:data-media3-$project.version"
+//    project.version = "dev-maint-media3-1_1-a1a44b0"
+//    at_1_0Implementation "com.mux.stats.sdk.muxstats:data-media3-ima-at_1_0:$project.version"
+//    at_1_1Implementation "com.mux.stats.sdk.muxstats:data-media3-ima-at_1_1:$project.version"
+//    latestImplementation "com.mux.stats.sdk.muxstats:data-media3-ima:$project.version"
+//    at_1_0Implementation "com.mux.stats.sdk.muxstats:data-media3-at_1_0:$project.version"
+//    at_1_1Implementation "com.mux.stats.sdk.muxstats:data-media3-at_1_1:$project.version"
+//    latestImplementation "com.mux.stats.sdk.muxstats:data-media3-$project.version"
 
 //    implementation "com.mux.stats.sdk.muxstats:data-media3-ima:${project.version}"
 //    implementation "com.mux.stats.sdk.muxstats:data-media3:${project.version}"
   }
 
-//  implementation project(":library-ima")
-//  implementation project(":library-exo")
-//  implementation project(":library")
+  implementation project(":library-ima")
+  implementation project(":library-exo")
+  implementation project(":library")
 
   //noinspection GradleDependency
   at_1_0Implementation "androidx.media3:media3-exoplayer:1.0.0"
@@ -103,7 +103,7 @@ dependencies {
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }
 
-configurations.all {
+configurations.configureEach {
   resolutionStrategy.dependencySubstitution {
     android.applicationVariants.each { variant ->
       def media3variant = variant.productFlavors.find { it.dimension == "media3" }.name
@@ -117,10 +117,10 @@ configurations.all {
       substitute module("com.mux.stats.sdk.muxstats:data-media3-custom${suffix()}")\
         using project(":library")\
         because "in development, we build from src"
-      substitute module("com.mux.stats.sdk.muxstats:data-media3${suffix()}") using \
+      substitute module("com.mux.stats.sdk.muxstats:data-media3${suffix()}") using\
         project(":library-exo")\
         because "in development, we build from src"
-      substitute module("com.mux.stats.sdk.muxstats:data-media3-ima${suffix()}") using \
+      substitute module("com.mux.stats.sdk.muxstats:data-media3-ima${suffix()}") using\
         project(":library-ima")\
         because "in development, we build from src"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ android {
     // We still need to declare different flavors so we can create version-specific variants
     at_1_0 { dimension "media3" }
     at_1_1 { dimension "media3" }
-    latest { dimension "media3" }
+    at_latest { dimension "media3" }
   }
 
   buildTypes {
@@ -72,13 +72,13 @@ dependencies {
   at_1_1Implementation "androidx.media3:media3-exoplayer-hls:1.1.0"
   at_1_1Implementation "androidx.media3:media3-exoplayer-rtsp:1.1.0"
 
-  latestImplementation "androidx.media3:media3-exoplayer:1.1.0"
-  latestImplementation "androidx.media3:media3-session:1.1.0"
-  latestImplementation "androidx.media3:media3-ui:1.1.0"
-  latestImplementation "androidx.media3:media3-exoplayer-ima:1.1.0"
-  latestImplementation "androidx.media3:media3-exoplayer-dash:1.1.0"
-  latestImplementation "androidx.media3:media3-exoplayer-hls:1.1.0"
-  latestImplementation "androidx.media3:media3-exoplayer-rtsp:1.1.0"
+  at_latestImplementation "androidx.media3:media3-exoplayer:1.1.0"
+  at_latestImplementation "androidx.media3:media3-session:1.1.0"
+  at_latestImplementation "androidx.media3:media3-ui:1.1.0"
+  at_latestImplementation "androidx.media3:media3-exoplayer-ima:1.1.0"
+  at_latestImplementation "androidx.media3:media3-exoplayer-dash:1.1.0"
+  at_latestImplementation "androidx.media3:media3-exoplayer-hls:1.1.0"
+  at_latestImplementation "androidx.media3:media3-exoplayer-rtsp:1.1.0"
 
   implementation 'androidx.core:core-ktx:1.9.0'
   implementation 'androidx.appcompat:appcompat:1.6.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,15 @@ android {
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
 
+  flavorDimensions = ["media3"]
+  productFlavors {
+    // This module does not currently need different src sets for different media3 versions.
+    // We still need to declare different flavors so we can create version-specific variants
+    at_1_0 { dimension "media3" }
+    at_1_1 { dimension "media3" }
+    latest { dimension "media3" }
+  }
+
   buildTypes {
     release {
       minifyEnabled false

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,17 +46,49 @@ android {
 
 dependencies {
   afterEvaluate {
-    implementation "com.mux.stats.sdk.muxstats:data-media3-ima:${project.version}"
-    implementation "com.mux.stats.sdk.muxstats:data-media3:${project.version}"
+    println ">>>> VERSION IS $project.version"
+    at_1_0Api "com.mux.stats.sdk.muxstats:data-media3-ima-at_1_0:$project.version"
+    at_1_1Api "com.mux.stats.sdk.muxstats:data-media3-ima-at_1_1:$project.version"
+    latestApi "com.mux.stats.sdk.muxstats:data-media3-ima:$project.version"
+    at_1_0Api "com.mux.stats.sdk.muxstats:data-media3-at_1_0:$project.version"
+    at_1_1Api "com.mux.stats.sdk.muxstats:data-media3-at_1_1:$project.version"
+    latestApi "com.mux.stats.sdk.muxstats:data-media3-$project.version"
+
+
+//    implementation "com.mux.stats.sdk.muxstats:data-media3-ima:${project.version}"
+//    implementation "com.mux.stats.sdk.muxstats:data-media3:${project.version}"
   }
 
-  implementation "androidx.media3:media3-exoplayer:${media3Version}"
-  implementation "androidx.media3:media3-exoplayer-dash:${media3Version}"
-  implementation "androidx.media3:media3-exoplayer-hls:${media3Version}"
-  implementation "androidx.media3:media3-exoplayer-rtsp:${media3Version}"
-  implementation "androidx.media3:media3-session:${media3Version}"
-  implementation "androidx.media3:media3-ui:${media3Version}"
-  implementation "androidx.media3:media3-exoplayer-ima:${media3Version}"
+  //noinspection GradleDependency
+  at_1_0Implementation "androidx.media3:media3-exoplayer:1.0.0"
+  //noinspection GradleDependency
+  at_1_0Implementation "androidx.media3:media3-session:1.0.0"
+  //noinspection GradleDependency
+  at_1_0Implementation "androidx.media3:media3-ui:1.0.0"
+  //noinspection GradleDependency
+  at_1_0Implementation "androidx.media3:media3-exoplayer-ima:1.0.0"
+  //noinspection GradleDependency
+  at_1_0Implementation "androidx.media3:media3-exoplayer-dash:1.0.0"
+  //noinspection GradleDependency
+  at_1_0Implementation "androidx.media3:media3-exoplayer-hls:1.0.0"
+  //noinspection GradleDependency
+  at_1_0Implementation "androidx.media3:media3-exoplayer-rtsp:1.0.0"
+
+  at_1_1Implementation "androidx.media3:media3-exoplayer:1.1.0"
+  at_1_1Implementation "androidx.media3:media3-session:1.1.0"
+  at_1_1Implementation "androidx.media3:media3-ui:1.1.0"
+  at_1_1Implementation "androidx.media3:media3-exoplayer-ima:1.1.0"
+  at_1_1Implementation "androidx.media3:media3-exoplayer-dash:1.1.0"
+  at_1_1Implementation "androidx.media3:media3-exoplayer-hls:1.1.0"
+  at_1_1Implementation "androidx.media3:media3-exoplayer-rtsp:1.1.0"
+
+  latestImplementation "androidx.media3:media3-exoplayer:1.1.0"
+  latestImplementation "androidx.media3:media3-session:1.1.0"
+  latestImplementation "androidx.media3:media3-ui:1.1.0"
+  latestImplementation "androidx.media3:media3-exoplayer-ima:1.1.0"
+  latestImplementation "androidx.media3:media3-exoplayer-dash:1.1.0"
+  latestImplementation "androidx.media3:media3-exoplayer-hls:1.1.0"
+  latestImplementation "androidx.media3:media3-exoplayer-rtsp:1.1.0"
 
   implementation 'androidx.core:core-ktx:1.9.0'
   implementation 'androidx.appcompat:appcompat:1.6.0'
@@ -69,11 +101,26 @@ dependencies {
 
 configurations.all {
   resolutionStrategy.dependencySubstitution {
-    substitute module("com.mux.stats.sdk.muxstats:data-media3-custom") using project(":library")\
-      because "In development, we build from src"
-    substitute module("com.mux.stats.sdk.muxstats:data-media3") using \
-      project(":library-exo") because "In development, we build from src"
-    substitute module("com.mux.stats.sdk.muxstats:data-media3-ima") using \
-      project(":library-ima") because "In development, we build from src"
+    android.applicationVariants.each { variant ->
+      def media3Variant = variant.productFlavors.find { it.dimension == "media3" }.name
+      def suffix = {
+        if (media3Variant.containsIgnoreCase("latest")) {
+          return ""
+        } else {
+          return "-$media3Variant"
+        }
+      }
+      substitute module("com.mux.stats.sdk.muxstats:data-media3-custom${suffix()}")\
+        using project(":library")\
+        because "In development, we build from src"
+      substitute module("com.mux.stats.sdk.muxstats:data-media3${suffix()}") using \
+        project(":library-exo")\
+        because "In development, we build from src"
+      substitute module("com.mux.stats.sdk.muxstats:data-media3-ima${suffix()}") using \
+        project(":library-ima")\
+        because "In development, we build from src"
+
+      }
   }
 }
+

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,20 +47,21 @@ android {
 dependencies {
   afterEvaluate {
 //    println ">>>> VERSION IS $project.version"
-//    at_1_0Api "com.mux.stats.sdk.muxstats:data-media3-ima-at_1_0:$project.version"
-//    at_1_1Api "com.mux.stats.sdk.muxstats:data-media3-ima-at_1_1:$project.version"
-//    latestApi "com.mux.stats.sdk.muxstats:data-media3-ima:$project.version"
-//    at_1_0Api "com.mux.stats.sdk.muxstats:data-media3-at_1_0:$project.version"
-//    at_1_1Api "com.mux.stats.sdk.muxstats:data-media3-at_1_1:$project.version"
-//    latestApi "com.mux.stats.sdk.muxstats:data-media3-$project.version"
+    project.version = "dev-maint-media3-1_1-a1a44b0"
+    at_1_0Api "com.mux.stats.sdk.muxstats:data-media3-ima-at_1_0:$project.version"
+    at_1_1Api "com.mux.stats.sdk.muxstats:data-media3-ima-at_1_1:$project.version"
+    latestApi "com.mux.stats.sdk.muxstats:data-media3-ima:$project.version"
+    at_1_0Api "com.mux.stats.sdk.muxstats:data-media3-at_1_0:$project.version"
+    at_1_1Api "com.mux.stats.sdk.muxstats:data-media3-at_1_1:$project.version"
+    latestApi "com.mux.stats.sdk.muxstats:data-media3-$project.version"
 
 //    implementation "com.mux.stats.sdk.muxstats:data-media3-ima:${project.version}"
 //    implementation "com.mux.stats.sdk.muxstats:data-media3:${project.version}"
   }
 
-  implementation project(":library-ima")
-  implementation project(":library-exo")
-  implementation project(":library")
+//  implementation project(":library-ima")
+//  implementation project(":library-exo")
+//  implementation project(":library")
 
   //noinspection GradleDependency
   at_1_0Implementation "androidx.media3:media3-exoplayer:1.0.0"
@@ -102,28 +103,28 @@ dependencies {
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }
 
-//configurations.all {
-//  resolutionStrategy.dependencySubstitution {
-//    android.applicationVariants.each { variant ->
-//      def media3Variant = variant.productFlavors.find { it.dimension == "media3" }.name
-//      def suffix = {
-//        if (media3Variant.containsIgnoreCase("latest")) {
-//          return ""
-//        } else {
-//          return "-$media3Variant"
-//        }
-//      }
-//      substitute module("com.mux.stats.sdk.muxstats:data-media3-custom${suffix()}")\
-//        using project(":library")\
-//        because "In development, we build from src"
-//      substitute module("com.mux.stats.sdk.muxstats:data-media3${suffix()}") using \
-//        project(":library-exo")\
-//        because "In development, we build from src"
-//      substitute module("com.mux.stats.sdk.muxstats:data-media3-ima${suffix()}") using \
-//        project(":library-ima")\
-//        because "In development, we build from src"
-//
-//      }
-//  }
-//}
+configurations.all {
+  resolutionStrategy.dependencySubstitution {
+    android.applicationVariants.each { variant ->
+      def media3variant = variant.productFlavors.find { it.dimension == "media3" }.name
+      def suffix = {
+        if (media3variant.containsIgnoreCase("latest")) {
+          return ""
+        } else {
+          return "-$media3variant"
+        }
+      }
+      substitute module("com.mux.stats.sdk.muxstats:data-media3-custom${suffix()}")\
+        using project(":library")\
+        because "in development, we build from src"
+      substitute module("com.mux.stats.sdk.muxstats:data-media3${suffix()}") using \
+        project(":library-exo")\
+        because "in development, we build from src"
+      substitute module("com.mux.stats.sdk.muxstats:data-media3-ima${suffix()}") using \
+        project(":library-ima")\
+        because "in development, we build from src"
+
+      }
+  }
+}
 

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/Util.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/Util.kt
@@ -3,5 +3,5 @@ package com.mux.stats.muxdatasdkformedia3
 import android.net.Uri
 import androidx.media3.common.MediaItem
 
-internal fun String.toUri() = Uri.parse(this)
-internal fun String.toMediaItem() = MediaItem.fromUri(toUri())
+fun String.toUri(): Uri = Uri.parse(this)
+fun String.toMediaItem() = MediaItem.fromUri(toUri())

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-  id 'com.android.application' version '8.0.2' apply false
-  id 'com.android.library' version '8.0.2' apply false
+  id 'com.android.application' version '8.1.0' apply false
+  id 'com.android.library' version '8.1.0' apply false
   id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
   id 'com.mux.gradle.android.mux-android-distribution' version '1.1.2' apply false
   id "org.jetbrains.dokka" version "1.6.10"
@@ -10,7 +10,7 @@ plugins {
 
 allprojects {
   project.ext {
-    media3Version = '1.0.2'
+    media3Version = '1.1.0'
     coreVersion = '0.7.5'
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ plugins {
 
 allprojects {
   project.ext {
-    media3Version = '1.1.0'
     coreVersion = '0.7.5'
   }
 

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -22,7 +22,7 @@ android {
     // We still need to declare different flavors so we can create version-specific variants
     at_1_0 { dimension "media3" }
     at_1_1 { dimension "media3" }
-    latest { dimension "media3" }
+    at_latest { dimension "media3" }
   }
 
   buildTypes {
@@ -45,7 +45,7 @@ muxDistribution {
   releaseVersion versionFromTag()
   artifactIds { variant ->
     def media3Variant = variant.productFlavors.find { it.dimension == "media3" }.name
-    if (media3Variant.containsIgnoreCase("latest")) {
+    if (media3Variant.containsIgnoreCase("at_latest")) {
       return "data-media3"
     } else {
       return "data-media3-$media3Variant"
@@ -101,8 +101,8 @@ dependencies {
   at_1_1Api "androidx.media3:media3-exoplayer:1.1.0"
   at_1_1CompileOnly "androidx.media3:media3-exoplayer-hls:1.1.0"
 
-  latestApi "androidx.media3:media3-exoplayer:1.1.0"
-  latestCompileOnly "androidx.media3:media3-exoplayer-hls:1.1.0"
+  at_latestApi "androidx.media3:media3-exoplayer:1.1.0"
+  at_latestCompileOnly "androidx.media3:media3-exoplayer-hls:1.1.0"
 
   implementation 'androidx.core:core-ktx:1.10.1'
   implementation 'androidx.appcompat:appcompat:1.6.1'
@@ -119,8 +119,8 @@ afterEvaluate {
   android.libraryVariants.findAll { it.buildType.name.contains("release") }
           .each { variant ->
             def suffix = variant.productFlavors.get(0).name
-            if (suffix.containsIgnoreCase("latest")) {
-              suffix = "" // 'latest' variant has no -at_X_X
+            if (suffix.containsIgnoreCase("at_latest")) {
+              suffix = "" // 'at_latest' variant has no -at_X_X
             } else {
               suffix = "-$suffix"
             }

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -157,9 +157,7 @@ afterEvaluate {
               suffix = "-$suffix"
             }
             def depNotation =
-                    "com.mux.stats.sdk.muxstats" +
-                            ":data-media3-custom${suffix}" +
-                            ":${project.version}"
+                    "com.mux.stats.sdk.muxstats:data-media3-custom${suffix}:${project.version}"
             def sourceSet = variant.sourceSets.reverse()[0] // Last src set is most specific
             // would be the same as declaring eg, r2_18_1ReleaseApi
             project.dependencies.add(sourceSet.apiConfigurationName, depNotation)

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -16,6 +16,15 @@ android {
     consumerProguardFiles "consumer-rules.pro"
   }
 
+  flavorDimensions = ["media3"]
+  productFlavors {
+    // This module does not currently need different src sets for different media3 versions.
+    // We still need to declare different flavors so we can create version-specific variants
+    at_1_0 { dimension "media3" }
+    at_1_1 { dimension "media3" }
+    latest { dimension "media3" }
+  }
+
   buildTypes {
     release {
       minifyEnabled false
@@ -79,8 +88,19 @@ dependencies {
   // implementation is used so it doesn't pollute customers namespace
   implementation "com.mux:utils-kt:$coreVersion"
 
-  api "androidx.media3:media3-exoplayer:$media3Version" // TODO: Not all of exo is required
-  compileOnly "androidx.media3:media3-exoplayer-hls:$media3Version"
+//  api "androidx.media3:media3-exoplayer:$media3Version" // TODO: Not all of exo is required
+//  compileOnly "androidx.media3:media3-exoplayer-hls:$media3Version"
+
+  //noinspection GradleDependency
+  at_1_0Api "androidx.media3:media3-exoplayer:1.0.0"
+  //noinspection GradleDependency
+  at_1_0CompileOnly "androidx.media3:media3-exoplayer-hls:1.0.0"
+
+  at_1_1Api "androidx.media3:media3-exoplayer:1.1.0"
+  at_1_1CompileOnly "androidx.media3:media3-exoplayer-hls:1.1.0"
+
+  latestApi "androidx.media3:media3-exoplayer:1.1.0"
+  latestCompileOnly "androidx.media3:media3-exoplayer-hls:1.1.0"
 
   implementation 'androidx.core:core-ktx:1.10.1'
   implementation 'androidx.appcompat:appcompat:1.6.1'

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -43,7 +43,14 @@ android {
 muxDistribution {
   devVersion versionFromCommitHash('dev-')
   releaseVersion versionFromTag()
-  artifactIds just("data-media3")
+  artifactIds { variant ->
+    def media3Variant = variant.productFlavors.find { it.dimension == "media3" }.name
+    if (media3Variant.containsIgnoreCase("latest")) {
+      return "data-media3"
+    } else {
+      return "data-media3-$media3Variant"
+    }
+  }
   groupIds just("com.mux.stats.sdk.muxstats")
   publicReleaseIf releaseOnTag()
 

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -90,7 +90,9 @@ muxDistribution {
 dependencies {
   afterEvaluate {
     // The version won't be available when `dependencies` is evaluated
-    api "com.mux.stats.sdk.muxstats:data-media3-custom:$project.version"
+    at_1_0Api "com.mux.stats.sdk.muxstats:data-media3-custom-at_1_0:$project.version"
+    at_1_1Api "com.mux.stats.sdk.muxstats:data-media3-custom-at_1_1:$project.version"
+    latestApi "com.mux.stats.sdk.muxstats:data-media3-custom:$project.version"
   }
   // implementation is used so it doesn't pollute customers namespace
   implementation "com.mux:utils-kt:$coreVersion"
@@ -120,7 +122,11 @@ dependencies {
 configurations.all {
   resolutionStrategy.dependencySubstitution {
     substitute module("com.mux.stats.sdk.muxstats:data-media3-custom") using project(":library")\
-      because "In development, we build from src"
+      because "When developing, we want the version from src"
+    substitute module("com.mux.stats.sdk.muxstats:data-media3-custom-at_1_0") using project(":library")\
+      because "When developing, we want the version from src"
+    substitute module("com.mux.stats.sdk.muxstats:data-media3-custom-at_1_1") using project(":library")\
+      because "When developing, we want the version from src"
   }
 }
 

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -88,14 +88,16 @@ muxDistribution {
 }
 
 dependencies {
-  afterEvaluate {
-    // The version won't be available when `dependencies` is evaluated
-    at_1_0Api "com.mux.stats.sdk.muxstats:data-media3-custom-at_1_0:$project.version"
-    at_1_1Api "com.mux.stats.sdk.muxstats:data-media3-custom-at_1_1:$project.version"
-    latestApi "com.mux.stats.sdk.muxstats:data-media3-custom:$project.version"
-  }
+//  afterEvaluate {
+//     The version won't be available when `dependencies` is evaluated
+//    at_1_0Api "com.mux.stats.sdk.muxstats:data-media3-custom-at_1_0:$project.version"
+//    at_1_1Api "com.mux.stats.sdk.muxstats:data-media3-custom-at_1_1:$project.version"
+//    latestApi "com.mux.stats.sdk.muxstats:data-media3-custom:$project.version"
+//  }
   // implementation is used so it doesn't pollute customers namespace
   implementation "com.mux:utils-kt:$coreVersion"
+
+  implementation project(':library')
 
 //  api "androidx.media3:media3-exoplayer:$media3Version" // TODO: Not all of exo is required
 //  compileOnly "androidx.media3:media3-exoplayer-hls:$media3Version"
@@ -119,27 +121,42 @@ dependencies {
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }
 
-configurations.all {
-  resolutionStrategy.dependencySubstitution {
-    android.libraryVariants.each { variant ->
-      def media3Variant = variant.productFlavors.find { it.dimension == "media3" }.name
-      def suffix = {
-        if (media3Variant.containsIgnoreCase("latest")) {
-          return ""
-        } else {
-          return "-$media3Variant"
-        }
-      }
-      println(">>>\"com.mux.stats.sdk.muxstats:data-media3-custom${suffix()}\"")
-      substitute module("com.mux.stats.sdk.muxstats:data-media3-custom${suffix()}")\
-        using project(":library")\
-        because "In development, we build from src"
-
-    }
+//configurations.configureEach {
+//  resolutionStrategy.dependencySubstitution {
+//    android.libraryVariants.each { variant ->
+//      def media3Variant = variant.productFlavors.find { it.dimension == "media3" }.name
+//      def suffix = {
+//        if (media3Variant.containsIgnoreCase("latest")) {
+//          return ""
+//        } else {
+//          return "-$media3Variant"
+//        }
+//      }
+//      println(">>>\"com.mux.stats.sdk.muxstats:data-media3-custom${suffix()}\"")
+//      substitute module("com.mux.stats.sdk.muxstats:data-media3-custom${suffix()}")\
+//        using project(":library")\
+//        because "In development, we build from src"
+//
+//    }
 //    substitute module("com.mux.stats.sdk.muxstats:data-media3-custom")\
 //        using project(":library")\
 //        because "In development, we build from src"
-  }
-}
+//  }
+//}
 
+afterEvaluate {
+  // Add dependency on ExoPlayerAdapter lib via mvn, which is also variant-aware
+  //  We only want to add this to release builds, and it has to be the same variant to work.
+  //  There's r2_18_1Api '..' and releaseApi '..', but no r2_18_1ReleaseApi '..'
+  android.libraryVariants.findAll { it.buildType.name.contains("release") }
+          .each { variant ->
+            def depNotation =
+                    "com.mux.stats.sdk.muxstats" +
+                            ":data-media3-custom${variant.productFlavors.get(0).name}" +
+                            ":${project.version}"
+            def sourceSet = variant.sourceSets.reverse()[0] // Last src set is most specific
+            // would be the same as declaring eg, r2_18_1ReleaseApi
+            project.dependencies.add(sourceSet.apiConfigurationName, depNotation)
+          }
+}
 

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -121,12 +121,20 @@ dependencies {
 
 configurations.all {
   resolutionStrategy.dependencySubstitution {
-    substitute module("com.mux.stats.sdk.muxstats:data-media3-custom") using project(":library")\
-      because "When developing, we want the version from src"
-    substitute module("com.mux.stats.sdk.muxstats:data-media3-custom-at_1_0") using project(":library")\
-      because "When developing, we want the version from src"
-    substitute module("com.mux.stats.sdk.muxstats:data-media3-custom-at_1_1") using project(":library")\
-      because "When developing, we want the version from src"
+    android.libraryVariants.each { variant ->
+      def media3Variant = variant.productFlavors.find { it.dimension == "media3" }.name
+      def suffix = {
+        if (media3Variant.containsIgnoreCase("latest")) {
+          return ""
+        } else {
+          return "-$media3Variant"
+        }
+      }
+      substitute module("com.mux.stats.sdk.muxstats:data-media3-custom${suffix()}")\
+        using project(":library")\
+        because "In development, we build from src"
+
+    }
   }
 }
 

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -97,7 +97,7 @@ dependencies {
   // implementation is used so it doesn't pollute customers namespace
   implementation "com.mux:utils-kt:$coreVersion"
 
-  implementation project(':library')
+  debugImplementation project(':library')
 
 //  api "androidx.media3:media3-exoplayer:$media3Version" // TODO: Not all of exo is required
 //  compileOnly "androidx.media3:media3-exoplayer-hls:$media3Version"
@@ -150,9 +150,15 @@ afterEvaluate {
   //  There's r2_18_1Api '..' and releaseApi '..', but no r2_18_1ReleaseApi '..'
   android.libraryVariants.findAll { it.buildType.name.contains("release") }
           .each { variant ->
+            def suffix = variant.productFlavors.get(0).name
+            if (suffix.containsIgnoreCase("latest")) {
+              suffix = "" // 'latest' variant has no -at_X_X
+            } else {
+              suffix = "-$suffix"
+            }
             def depNotation =
                     "com.mux.stats.sdk.muxstats" +
-                            ":data-media3-custom${variant.productFlavors.get(0).name}" +
+                            ":data-media3-custom${suffix}" +
                             ":${project.version}"
             def sourceSet = variant.sourceSets.reverse()[0] // Last src set is most specific
             // would be the same as declaring eg, r2_18_1ReleaseApi

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -88,19 +88,10 @@ muxDistribution {
 }
 
 dependencies {
-//  afterEvaluate {
-//     The version won't be available when `dependencies` is evaluated
-//    at_1_0Api "com.mux.stats.sdk.muxstats:data-media3-custom-at_1_0:$project.version"
-//    at_1_1Api "com.mux.stats.sdk.muxstats:data-media3-custom-at_1_1:$project.version"
-//    latestApi "com.mux.stats.sdk.muxstats:data-media3-custom:$project.version"
-//  }
   // implementation is used so it doesn't pollute customers namespace
   implementation "com.mux:utils-kt:$coreVersion"
 
   debugImplementation project(':library')
-
-//  api "androidx.media3:media3-exoplayer:$media3Version" // TODO: Not all of exo is required
-//  compileOnly "androidx.media3:media3-exoplayer-hls:$media3Version"
 
   //noinspection GradleDependency
   at_1_0Api "androidx.media3:media3-exoplayer:1.0.0"
@@ -121,33 +112,10 @@ dependencies {
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }
 
-//configurations.configureEach {
-//  resolutionStrategy.dependencySubstitution {
-//    android.libraryVariants.each { variant ->
-//      def media3Variant = variant.productFlavors.find { it.dimension == "media3" }.name
-//      def suffix = {
-//        if (media3Variant.containsIgnoreCase("latest")) {
-//          return ""
-//        } else {
-//          return "-$media3Variant"
-//        }
-//      }
-//      println(">>>\"com.mux.stats.sdk.muxstats:data-media3-custom${suffix()}\"")
-//      substitute module("com.mux.stats.sdk.muxstats:data-media3-custom${suffix()}")\
-//        using project(":library")\
-//        because "In development, we build from src"
-//
-//    }
-//    substitute module("com.mux.stats.sdk.muxstats:data-media3-custom")\
-//        using project(":library")\
-//        because "In development, we build from src"
-//  }
-//}
-
 afterEvaluate {
-  // Add dependency on ExoPlayerAdapter lib via mvn, which is also variant-aware
+  // Release builds need mvn coordinates to depend on modules from this project
   //  We only want to add this to release builds, and it has to be the same variant to work.
-  //  There's r2_18_1Api '..' and releaseApi '..', but no r2_18_1ReleaseApi '..'
+  //  There's 'at_1_1Api '..' and releaseApi '..', but no at_1_1ReleaseApi '..'
   android.libraryVariants.findAll { it.buildType.name.contains("release") }
           .each { variant ->
             def suffix = variant.productFlavors.get(0).name
@@ -159,7 +127,6 @@ afterEvaluate {
             def depNotation =
                     "com.mux.stats.sdk.muxstats:data-media3-custom${suffix}:${project.version}"
             def sourceSet = variant.sourceSets.reverse()[0] // Last src set is most specific
-            // would be the same as declaring eg, r2_18_1ReleaseApi
             project.dependencies.add(sourceSet.apiConfigurationName, depNotation)
           }
 }

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -130,11 +130,15 @@ configurations.all {
           return "-$media3Variant"
         }
       }
+      println(">>>\"com.mux.stats.sdk.muxstats:data-media3-custom${suffix()}\"")
       substitute module("com.mux.stats.sdk.muxstats:data-media3-custom${suffix()}")\
         using project(":library")\
         because "In development, we build from src"
 
     }
+//    substitute module("com.mux.stats.sdk.muxstats:data-media3-custom")\
+//        using project(":library")\
+//        because "In development, we build from src"
   }
 }
 

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -41,6 +41,7 @@ android {
 }
 
 muxDistribution {
+  println(">>>muxDistribution")
   devVersion versionFromCommitHash('dev-')
   releaseVersion versionFromTag()
   artifactIds { variant ->
@@ -129,5 +130,8 @@ configurations.all {
         because "In development, we build from src"
 
     }
+//    substitute module("com.mux.stats.sdk.muxstats:data-media3-custom")\
+//        using project(":library")\
+//        because "In development, we build from src"
   }
 }

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -151,9 +151,7 @@ afterEvaluate {
               suffix = "-$suffix"
             }
             def depNotation =
-                    "com.mux.stats.sdk.muxstats" +
-                            ":data-media3-custom${suffix}" +
-                            ":${project.version}"
+                    "com.mux.stats.sdk.muxstats:data-media3-custom${suffix}:${project.version}"
             def sourceSet = variant.sourceSets.reverse()[0] // Last src set is most specific
             // would be the same as declaring eg, r2_18_1ReleaseApi
             project.dependencies.add(sourceSet.apiConfigurationName, depNotation)

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -89,7 +89,9 @@ muxDistribution {
 
 dependencies {
   afterEvaluate {
-    api "com.mux.stats.sdk.muxstats:data-media3-custom:$project.version"
+    at_1_0Api "com.mux.stats.sdk.muxstats:data-media3-custom-at_1_0:$project.version"
+    at_1_1Api "com.mux.stats.sdk.muxstats:data-media3-custom-at_1_1:$project.version"
+    latestApi "com.mux.stats.sdk.muxstats:data-media3-custom:$project.version"
   }
   
   // note- 3.30.0 and 3.30.1 are marked as broken by google, so don't use
@@ -114,6 +116,10 @@ dependencies {
 configurations.all {
   resolutionStrategy.dependencySubstitution {
     substitute module("com.mux.stats.sdk.muxstats:data-media3-custom") using project(":library")\
-      because "In development, we build from src"
+      because "When devleoping, we want the version from src"
+    substitute module("com.mux.stats.sdk.muxstats:data-media3-custom-at_1_0") using project(":library")\
+      because "When devleoping, we want the version from src"
+    substitute module("com.mux.stats.sdk.muxstats:data-media3-custom-at_1_1") using project(":library")\
+      because "When devleoping, we want the version from src"
   }
 }

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -41,7 +41,6 @@ android {
 }
 
 muxDistribution {
-  println(">>>muxDistribution")
   devVersion versionFromCommitHash('dev-')
   releaseVersion versionFromTag()
   artifactIds { variant ->

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -43,7 +43,14 @@ android {
 muxDistribution {
   devVersion versionFromCommitHash('dev-')
   releaseVersion versionFromTag()
-  artifactIds just("data-media3-ima")
+  artifactIds { variant ->
+    def media3Variant = variant.productFlavors.find { it.dimension == "media3" }.name
+    if (media3Variant.containsIgnoreCase("latest")) {
+      return "data-media3-ima"
+    } else {
+      return "data-media3-ima-$media3Variant"
+    }
+  }
   groupIds just("com.mux.stats.sdk.muxstats")
   publicReleaseIf releaseOnTag()
 

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -16,6 +16,15 @@ android {
     consumerProguardFiles "consumer-rules.pro"
   }
 
+  flavorDimensions = ["media3"]
+  productFlavors {
+    // This module does not currently need different src sets for different media3 versions.
+    // We still need to declare different flavors so we can create version-specific variants
+    at_1_0 { dimension "media3" }
+    at_1_1 { dimension "media3" }
+    latest { dimension "media3" }
+  }
+
   buildTypes {
     release {
       minifyEnabled false
@@ -78,9 +87,14 @@ dependencies {
   
   // note- 3.30.0 and 3.30.1 are marked as broken by google, so don't use
   api 'com.google.ads.interactivemedia.v3:interactivemedia:3.29.0'
-  implementation "androidx.media3:media3-exoplayer-ima:${media3Version}"
+//  implementation "androidx.media3:media3-exoplayer-ima:${media3Version}"
   // implementation is used so it doesn't pollute customers namespace
   implementation "com.mux:utils-kt:$coreVersion"
+
+  //noinspection GradleDependency
+  at_1_0Api "androidx.media3:media3-exoplayer-ima:1.0.0"
+  at_1_1Api "androidx.media3:media3-exoplayer-ima:1.1.0"
+  latestApi "androidx.media3:media3-exoplayer-ima:1.1.0"
 
   implementation 'androidx.core:core-ktx:1.10.1'
   implementation 'androidx.appcompat:appcompat:1.6.1'

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -22,7 +22,7 @@ android {
     // We still need to declare different flavors so we can create version-specific variants
     at_1_0 { dimension "media3" }
     at_1_1 { dimension "media3" }
-    latest { dimension "media3" }
+    at_latest { dimension "media3" }
   }
 
   buildTypes {
@@ -45,7 +45,7 @@ muxDistribution {
   releaseVersion versionFromTag()
   artifactIds { variant ->
     def media3Variant = variant.productFlavors.find { it.dimension == "media3" }.name
-    if (media3Variant.containsIgnoreCase("latest")) {
+    if (media3Variant.containsIgnoreCase("at_latest")) {
       return "data-media3-ima"
     } else {
       return "data-media3-ima-$media3Variant"
@@ -98,7 +98,7 @@ dependencies {
   //noinspection GradleDependency
   at_1_0Api "androidx.media3:media3-exoplayer-ima:1.0.0"
   at_1_1Api "androidx.media3:media3-exoplayer-ima:1.1.0"
-  latestApi "androidx.media3:media3-exoplayer-ima:1.1.0"
+  at_latestApi "androidx.media3:media3-exoplayer-ima:1.1.0"
 
   implementation 'androidx.core:core-ktx:1.10.1'
   implementation 'androidx.appcompat:appcompat:1.6.1'
@@ -115,8 +115,8 @@ afterEvaluate {
   android.libraryVariants.findAll { it.buildType.name.contains("release") }
           .each { variant ->
             def suffix = variant.productFlavors.get(0).name
-            if (suffix.containsIgnoreCase("latest")) {
-              suffix = "" // 'latest' variant has no -at_X_X
+            if (suffix.containsIgnoreCase("at_latest")) {
+              suffix = "" // 'at_latest' variant has no -at_X_X
             } else {
               suffix = "-$suffix"
             }

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -89,17 +89,10 @@ muxDistribution {
 }
 
 dependencies {
-//  afterEvaluate {
-//    at_1_0Api "com.mux.stats.sdk.muxstats:data-media3-custom-at_1_0:$project.version"
-//    at_1_1Api "com.mux.stats.sdk.muxstats:data-media3-custom-at_1_1:$project.version"
-//    latestApi "com.mux.stats.sdk.muxstats:data-media3-custom:$project.version"
-//  }
-
   debugImplementation project(':library')
   
   // note- 3.30.0 and 3.30.1 are marked as broken by google, so don't use
   api 'com.google.ads.interactivemedia.v3:interactivemedia:3.29.0'
-//  implementation "androidx.media3:media3-exoplayer-ima:${media3Version}"
   // implementation is used so it doesn't pollute customers namespace
   implementation "com.mux:utils-kt:$coreVersion"
 
@@ -116,32 +109,10 @@ dependencies {
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }
 
-//configurations.configureEach {
-//  resolutionStrategy.dependencySubstitution {
-//    android.libraryVariants.each { variant ->
-//      def media3Variant = variant.productFlavors.find { it.dimension == "media3" }.name
-//      def suffix = {
-//        if (media3Variant.containsIgnoreCase("latest")) {
-//          return ""
-//        } else {
-//          return "-$media3Variant"
-//        }
-//      }
-//      substitute module("com.mux.stats.sdk.muxstats:data-media3-custom${suffix()}")\
-//        using project(":library")\
-//        because "In development, we build from src"
-//
-//    }
-//    substitute module("com.mux.stats.sdk.muxstats:data-media3-custom")\
-//        using project(":library")\
-//        because "In development, we build from src"
-//  }
-//}
-
 afterEvaluate {
-  // Add dependency on ExoPlayerAdapter lib via mvn, which is also variant-aware
+  // Release builds need mvn coordinates to depend on modules from this project
   //  We only want to add this to release builds, and it has to be the same variant to work.
-  //  There's r2_18_1Api '..' and releaseApi '..', but no r2_18_1ReleaseApi '..'
+  //  There's 'at_1_1Api '..' and releaseApi '..', but no at_1_1ReleaseApi '..'
   android.libraryVariants.findAll { it.buildType.name.contains("release") }
           .each { variant ->
             def suffix = variant.productFlavors.get(0).name
@@ -153,7 +124,6 @@ afterEvaluate {
             def depNotation =
                     "com.mux.stats.sdk.muxstats:data-media3-custom${suffix}:${project.version}"
             def sourceSet = variant.sourceSets.reverse()[0] // Last src set is most specific
-            // would be the same as declaring eg, r2_18_1ReleaseApi
             project.dependencies.add(sourceSet.apiConfigurationName, depNotation)
           }
 }

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -89,11 +89,13 @@ muxDistribution {
 }
 
 dependencies {
-  afterEvaluate {
-    at_1_0Api "com.mux.stats.sdk.muxstats:data-media3-custom-at_1_0:$project.version"
-    at_1_1Api "com.mux.stats.sdk.muxstats:data-media3-custom-at_1_1:$project.version"
-    latestApi "com.mux.stats.sdk.muxstats:data-media3-custom:$project.version"
-  }
+//  afterEvaluate {
+//    at_1_0Api "com.mux.stats.sdk.muxstats:data-media3-custom-at_1_0:$project.version"
+//    at_1_1Api "com.mux.stats.sdk.muxstats:data-media3-custom-at_1_1:$project.version"
+//    latestApi "com.mux.stats.sdk.muxstats:data-media3-custom:$project.version"
+//  }
+
+  implementation project(':library')
   
   // note- 3.30.0 and 3.30.1 are marked as broken by google, so don't use
   api 'com.google.ads.interactivemedia.v3:interactivemedia:3.29.0'
@@ -114,24 +116,40 @@ dependencies {
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }
 
-configurations.all {
-  resolutionStrategy.dependencySubstitution {
-    android.libraryVariants.each { variant ->
-      def media3Variant = variant.productFlavors.find { it.dimension == "media3" }.name
-      def suffix = {
-        if (media3Variant.containsIgnoreCase("latest")) {
-          return ""
-        } else {
-          return "-$media3Variant"
-        }
-      }
-      substitute module("com.mux.stats.sdk.muxstats:data-media3-custom${suffix()}")\
-        using project(":library")\
-        because "In development, we build from src"
-
-    }
+//configurations.configureEach {
+//  resolutionStrategy.dependencySubstitution {
+//    android.libraryVariants.each { variant ->
+//      def media3Variant = variant.productFlavors.find { it.dimension == "media3" }.name
+//      def suffix = {
+//        if (media3Variant.containsIgnoreCase("latest")) {
+//          return ""
+//        } else {
+//          return "-$media3Variant"
+//        }
+//      }
+//      substitute module("com.mux.stats.sdk.muxstats:data-media3-custom${suffix()}")\
+//        using project(":library")\
+//        because "In development, we build from src"
+//
+//    }
 //    substitute module("com.mux.stats.sdk.muxstats:data-media3-custom")\
 //        using project(":library")\
 //        because "In development, we build from src"
-  }
+//  }
+//}
+
+afterEvaluate {
+  // Add dependency on ExoPlayerAdapter lib via mvn, which is also variant-aware
+  //  We only want to add this to release builds, and it has to be the same variant to work.
+  //  There's r2_18_1Api '..' and releaseApi '..', but no r2_18_1ReleaseApi '..'
+  android.libraryVariants.findAll { it.buildType.name.contains("release") }
+          .each { variant ->
+            def depNotation =
+                    "com.mux.stats.sdk.muxstats" +
+                            ":data-media3-custom${variant.productFlavors.get(0).name}" +
+                            ":${project.version}"
+            def sourceSet = variant.sourceSets.reverse()[0] // Last src set is most specific
+            // would be the same as declaring eg, r2_18_1ReleaseApi
+            project.dependencies.add(sourceSet.apiConfigurationName, depNotation)
+          }
 }

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -95,7 +95,7 @@ dependencies {
 //    latestApi "com.mux.stats.sdk.muxstats:data-media3-custom:$project.version"
 //  }
 
-  implementation project(':library')
+  debugImplementation project(':library')
   
   // note- 3.30.0 and 3.30.1 are marked as broken by google, so don't use
   api 'com.google.ads.interactivemedia.v3:interactivemedia:3.29.0'
@@ -144,9 +144,15 @@ afterEvaluate {
   //  There's r2_18_1Api '..' and releaseApi '..', but no r2_18_1ReleaseApi '..'
   android.libraryVariants.findAll { it.buildType.name.contains("release") }
           .each { variant ->
+            def suffix = variant.productFlavors.get(0).name
+            if (suffix.containsIgnoreCase("latest")) {
+              suffix = "" // 'latest' variant has no -at_X_X
+            } else {
+              suffix = "-$suffix"
+            }
             def depNotation =
                     "com.mux.stats.sdk.muxstats" +
-                            ":data-media3-custom${variant.productFlavors.get(0).name}" +
+                            ":data-media3-custom${suffix}" +
                             ":${project.version}"
             def sourceSet = variant.sourceSets.reverse()[0] // Last src set is most specific
             // would be the same as declaring eg, r2_18_1ReleaseApi

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -115,11 +115,19 @@ dependencies {
 
 configurations.all {
   resolutionStrategy.dependencySubstitution {
-    substitute module("com.mux.stats.sdk.muxstats:data-media3-custom") using project(":library")\
-      because "When devleoping, we want the version from src"
-    substitute module("com.mux.stats.sdk.muxstats:data-media3-custom-at_1_0") using project(":library")\
-      because "When devleoping, we want the version from src"
-    substitute module("com.mux.stats.sdk.muxstats:data-media3-custom-at_1_1") using project(":library")\
-      because "When devleoping, we want the version from src"
+    android.libraryVariants.each { variant ->
+      def media3Variant = variant.productFlavors.find { it.dimension == "media3" }.name
+      def suffix = {
+        if (media3Variant.containsIgnoreCase("latest")) {
+          return ""
+        } else {
+          return "-$media3Variant"
+        }
+      }
+      substitute module("com.mux.stats.sdk.muxstats:data-media3-custom${suffix()}")\
+        using project(":library")\
+        because "In development, we build from src"
+
+    }
   }
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -18,6 +18,16 @@ android {
     buildConfigField "String", "MEDIA3_VERSION", "\"${media3Version}\""
   }
 
+  flavorDimensions = ["media3"]
+
+  productFlavors {
+    // This module does not currently need different src sets for different media3 versions.
+    // We still need to declare different flavors so we can create version-specific variants
+    at_1_0 { dimension "media3" }
+    at_1_1 { dimension "media3" }
+    latest { dimension "media3" }
+  }
+
   buildTypes {
     release {
       minifyEnabled false
@@ -36,7 +46,9 @@ android {
 muxDistribution {
   devVersion versionFromCommitHash('dev-')
   releaseVersion versionFromTag()
-  artifactIds just("data-media3-custom")
+  artifactIds { variant ->
+    def variantName = variant.name
+  }
   groupIds just("com.mux.stats.sdk.muxstats")
   publicReleaseIf releaseOnTag()
 
@@ -74,12 +86,16 @@ muxDistribution {
 }
 
 dependencies {
-//  def coreVersion = 'dev-covariant-binding-9a3773e'
   api "com.mux.stats.sdk.muxstats:android:$coreVersion"
-  api "androidx.media3:media3-common:$media3Version"
   // implementation is used so it doesn't pollute customers namespace
   implementation "com.mux:utils-kt:$coreVersion"
-  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1"
+
+  //noinspection GradleDependency
+  at_1_0Api "androidx.media3:media3-common:1.0.0"
+  at_1_1Api "androidx.media3:media3-common:1.1.0"
+  latestApi "androidx.media3:media3-common:1.1.0"
+
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
 
   testImplementation 'junit:junit:4.13.2'
   androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -50,6 +50,7 @@ muxDistribution {
     if (media3Variant.containsIgnoreCase("latest")) {
       return "data-media3-custom"
     } else {
+      println("I AM NAMED data-media3-custom-$media3Variant")
       return "data-media3-custom-$media3Variant"
     }
   }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -14,17 +14,24 @@ android {
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles "consumer-rules.pro"
-
-    buildConfigField "String", "MEDIA3_VERSION", "\"${media3Version}\""
   }
 
   flavorDimensions = ["media3"]
   productFlavors {
     // This module does not currently need different src sets for different media3 versions.
     // We still need to declare different flavors so we can create version-specific variants
-    at_1_0 { dimension "media3" }
-    at_1_1 { dimension "media3" }
-    latest { dimension "media3" }
+    at_1_0 {
+      dimension "media3"
+      buildConfigField "String", "MEDIA3_VERSION", "\"1.0.x\""
+    }
+    at_1_1 {
+      dimension "media3"
+      buildConfigField "String", "MEDIA3_VERSION", "\"1.1.x\""
+    }
+    at_latest {
+      dimension "media3"
+      buildConfigField "String", "MEDIA3_VERSION", "\"1.1.x\""
+    }
   }
 
   buildTypes {
@@ -47,7 +54,7 @@ muxDistribution {
   releaseVersion versionFromTag()
   artifactIds { variant ->
     def media3Variant = variant.productFlavors.find { it.dimension == "media3" }.name
-    if (media3Variant.containsIgnoreCase("latest")) {
+    if (media3Variant.containsIgnoreCase("at_latest")) {
       return "data-media3-custom"
     } else {
       return "data-media3-custom-$media3Variant"
@@ -97,7 +104,7 @@ dependencies {
   //noinspection GradleDependency
   at_1_0Api "androidx.media3:media3-common:1.0.0"
   at_1_1Api "androidx.media3:media3-common:1.1.0"
-  latestApi "androidx.media3:media3-common:1.1.0"
+  at_latestApi "androidx.media3:media3-common:1.1.0"
 
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -46,7 +46,12 @@ muxDistribution {
   devVersion versionFromCommitHash('dev-')
   releaseVersion versionFromTag()
   artifactIds { variant ->
-    def variantName = variant.name
+    def media3Variant = variant.productFlavors.find { it.dimension == "media3" }.name
+    if (media3Variant.containsIgnoreCase("latest")) {
+      return "data-media3-custom"
+    } else {
+      return "data-media3-custom-$media3Variant"
+    }
   }
   groupIds just("com.mux.stats.sdk.muxstats")
   publicReleaseIf releaseOnTag()

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -50,7 +50,6 @@ muxDistribution {
     if (media3Variant.containsIgnoreCase("latest")) {
       return "data-media3-custom"
     } else {
-      println("I AM NAMED data-media3-custom-$media3Variant")
       return "data-media3-custom-$media3Variant"
     }
   }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -19,7 +19,6 @@ android {
   }
 
   flavorDimensions = ["media3"]
-
   productFlavors {
     // This module does not currently need different src sets for different media3 versions.
     // We still need to declare different flavors so we can create version-specific variants


### PR DESCRIPTION
Adds version-aware variants of the Media3 SDK for 1.0.x and 1.1.x. This is the way we do it for ExoPlayer, and this is fairly necessary. ExoPlayer and media3 have a lot of APIs that change often, and we need to be able to support many versions of media3. Customers, especially our big media customers, don't do risky upgrades like exoplayer very often.

This differs from ExoPlayer in a few ways:
* We publish a version of our SDK that tracks the latest version we support. This variant has no special name
* Variants that are stuck to a specific version will be called `-at_1_1`, `-at_1_0`, and so on. This is the same deal as the Exo SDK's `r2_x_x` variants

I had to move away from dependency-substitution for depending on modules in the project. This is because the variant-aware `implementation` and `api` rules don't appear to work with dependency substitution. Instead, I just add mvn deps to release builds and project deps to debug builds.