### PR TITLE
fix: SSAI Ad events not properly reported

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,10 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
-            android:name=".examples.ima.ImaAdsActivity"
+            android:name=".examples.ima.ImaClientAdsActivity"
+            android:exported="false" />
+        <activity
+            android:name=".examples.ima.ImaServerAdsActivity"
             android:exported="false" />
         <activity
             android:name=".examples.background.BackgroundPlayActivity"

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/Constants.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/Constants.kt
@@ -8,4 +8,5 @@ object Constants {
   const val VOD_TEST_URL_BIG_BUCK_BUNNY = "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8"
   const val AD_TAG_SIMPLE_W_MID_ROLL = "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/vmap_ad_samples&sz=640x480&cust_params=sample_ar%3Dpremidpostoptimizedpod&ciu_szs=300x250&gdfp_req=1&ad_rule=1&output=vmap&unviewed_position_start=1&env=vp&impl=s&cmsid=496&vid=short_onecue&correlator="
   const val AD_TAG_COMPLEX = "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/vmap_ad_samples&sz=640x480&cust_params=sample_ar%3Dpremidpostlongpod&ciu_szs=300x250&gdfp_req=1&ad_rule=1&output=vmap&unviewed_position_start=1&env=vp&impl=s&cmsid=496&vid=short_onecue&correlator="
+  const val SSAI_ASSET_TAG_BUCK = "c-rArva4ShKVIAkNfy6HUQ"
 }

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/Constants.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/Constants.kt
@@ -1,7 +1,7 @@
 package com.mux.stats.muxdatasdkformedia3
 
 object Constants {
-  const val MUX_DATA_ENV_KEY = "YOUR MUX DATA ENV KEY HERE"
+  const val MUX_DATA_ENV_KEY = "rhhn9fph0nog346n4tqb6bqda"
   const val VOD_TEST_URL_STEVE = "http://qthttp.apple.com.edgesuite.net/1010qwoeiuryfg/sl.m3u8"
   const val VOD_TEST_URL_DRAGON_WARRIOR_LADY =
     "https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8"

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/Constants.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/Constants.kt
@@ -1,7 +1,7 @@
 package com.mux.stats.muxdatasdkformedia3
 
 object Constants {
-  const val MUX_DATA_ENV_KEY = "rhhn9fph0nog346n4tqb6bqda"
+  const val MUX_DATA_ENV_KEY = "YOUR MUX DATA ENV KEY HERE"
   const val VOD_TEST_URL_STEVE = "http://qthttp.apple.com.edgesuite.net/1010qwoeiuryfg/sl.m3u8"
   const val VOD_TEST_URL_DRAGON_WARRIOR_LADY =
     "https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8"

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/MainActivity.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/MainActivity.kt
@@ -3,7 +3,6 @@ package com.mux.stats.muxdatasdkformedia3
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -12,9 +11,9 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.mux.stats.muxdatasdkformedia3.databinding.ActivityMainBinding
 import com.mux.stats.muxdatasdkformedia3.databinding.ListitemExampleBinding
-import com.mux.stats.muxdatasdkformedia3.examples.background.BackgroundPlayActivity
 import com.mux.stats.muxdatasdkformedia3.examples.basic.BasicPlayerActivity
-import com.mux.stats.muxdatasdkformedia3.examples.ima.ImaAdsActivity
+import com.mux.stats.muxdatasdkformedia3.examples.ima.ImaClientAdsActivity
+import com.mux.stats.muxdatasdkformedia3.examples.ima.ImaServerAdsActivity
 
 class MainActivity : AppCompatActivity() {
 
@@ -34,8 +33,12 @@ class MainActivity : AppCompatActivity() {
       destination = Intent(this, BasicPlayerActivity::class.java)
     ),
     Example(
-      title = "IMA Ads",
-      destination = Intent(this, ImaAdsActivity::class.java)
+      title = "IMA Ads (CSAI, most common)",
+      destination = Intent(this, ImaClientAdsActivity::class.java)
+    ),
+    Example(
+      title = "IMA Ads (DAI/SSAI, less common)",
+      destination = Intent(this, ImaServerAdsActivity::class.java)
     ),
     Example(
       title = "Live Playback",

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaClientAdsActivity.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaClientAdsActivity.kt
@@ -27,7 +27,7 @@ import com.mux.stats.sdk.media3_ima.monitorWith
 import com.mux.stats.sdk.muxstats.MuxStatsSdkMedia3
 import com.mux.stats.sdk.muxstats.monitorWithMuxData
 
-class ImaAdsActivity : AppCompatActivity() {
+class ImaClientAdsActivity : AppCompatActivity() {
 
   private lateinit var view: ActivityPlayerBinding
   private var player: Player? = null
@@ -123,7 +123,7 @@ class ImaAdsActivity : AppCompatActivity() {
         addListener(object : Player.Listener {
           override fun onPlayerError(error: PlaybackException) {
             Log.e(javaClass.simpleName, "player error!", error)
-            Toast.makeText(this@ImaAdsActivity, error.localizedMessage, Toast.LENGTH_SHORT).show()
+            Toast.makeText(this@ImaClientAdsActivity, error.localizedMessage, Toast.LENGTH_SHORT).show()
           }
         })
       }

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaClientAdsActivity.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaClientAdsActivity.kt
@@ -42,6 +42,7 @@ class ImaClientAdsActivity : AppCompatActivity() {
 
     view.playerView.apply {
       setShowBuffering(PlayerView.SHOW_BUFFERING_WHEN_PLAYING)
+      controllerAutoShow = true
     }
     window.addFlags(View.KEEP_SCREEN_ON)
   }

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaServerAdsActivity.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaServerAdsActivity.kt
@@ -137,9 +137,10 @@ class ImaServerAdsActivity : AppCompatActivity() {
             .build()
         )
       }
-    }.also {
-      it?.prepare()
-      it?.playWhenReady = true
+    }
+    player?.let {
+      it.prepare()
+      it.playWhenReady = true
     }
   }
 

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaServerAdsActivity.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaServerAdsActivity.kt
@@ -61,15 +61,14 @@ class ImaServerAdsActivity : AppCompatActivity() {
     )
   }
 
-//  override fun onPause() {
-//    stopPlaying()
-//    super.onPause()
-//  }
+  override fun onPause() {
+    stopPlaying()
+    super.onPause()
+  }
 
   @OptIn(UnstableApi::class)
   override fun onSaveInstanceState(outState: Bundle, outPersistentState: PersistableBundle) {
     stopPlaying()
-    adsLoaderState = adsLoader?.release()
     adsLoaderState?.let {
       outState.putBundle(EXTRA_ADS_LOADER_STATE, it.toBundle())
     }
@@ -126,6 +125,7 @@ class ImaServerAdsActivity : AppCompatActivity() {
       oldPlayer.release()
     }
     // Make sure to release() your muxStats whenever the user is done with the player
+    adsLoaderState = adsLoader?.release()
     muxStats?.release()
   }
 

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaServerAdsActivity.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaServerAdsActivity.kt
@@ -27,6 +27,7 @@ import com.mux.stats.sdk.core.model.CustomerData
 import com.mux.stats.sdk.core.model.CustomerPlayerData
 import com.mux.stats.sdk.core.model.CustomerVideoData
 import com.mux.stats.sdk.core.model.CustomerViewData
+import com.mux.stats.sdk.media3_ima.monitorWith
 import com.mux.stats.sdk.muxstats.MuxStatsSdkMedia3
 import com.mux.stats.sdk.muxstats.monitorWithMuxData
 
@@ -59,7 +60,7 @@ class ImaServerAdsActivity : AppCompatActivity() {
     super.onResume()
     startPlaying(
       Constants.AD_TAG_COMPLEX,
-      createAdsLoaderIfNull(adsLoaderState, view.playerView)
+      createAdsLoaderIfNull(adsLoaderState, view.playerView, muxStats!!)
     )
   }
 
@@ -81,11 +82,18 @@ class ImaServerAdsActivity : AppCompatActivity() {
   @OptIn(UnstableApi::class)
   private fun createAdsLoaderIfNull(
     state: AdsLoader.State?,
-    playerView: PlayerView
+    playerView: PlayerView,
+    muxStats: MuxStatsSdkMedia3<*>,
   ): AdsLoader {
-    return AdsLoader.Builder(this, playerView)
-      .apply { state?.let { adsLoaderState = it } }
-      .build()
+    return adsLoader
+      ?: AdsLoader.Builder(this, playerView)
+        .apply { state?.let { adsLoaderState = it } }
+        .monitorWith(
+          muxStats,
+          { /*your ad event handling here*/ },
+          { /*your ad error handling here*/ },
+        )
+        .build()
   }
 
   @OptIn(UnstableApi::class)

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaServerAdsActivity.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaServerAdsActivity.kt
@@ -35,8 +35,8 @@ class ImaServerAdsActivity : AppCompatActivity() {
   private lateinit var view: ActivityPlayerBinding
   private var player: Player? = null
   private var muxStats: MuxStatsSdkMedia3<ExoPlayer>? = null
-  private var adsLoader: ImaServerSideAdInsertionMediaSource.AdsLoader? = null
-  private var adsLoaderState: ImaServerSideAdInsertionMediaSource.AdsLoader.State? = null
+  private var adsLoader: AdsLoader? = null
+  private var adsLoaderState: AdsLoader.State? = null
 
   @OptIn(UnstableApi::class)
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -50,7 +50,7 @@ class ImaServerAdsActivity : AppCompatActivity() {
     window.addFlags(View.KEEP_SCREEN_ON)
 
     adsLoaderState = savedInstanceState?.getBundle(EXTRA_ADS_LOADER_STATE)
-      ?.let { ImaServerSideAdInsertionMediaSource.AdsLoader.State.CREATOR.fromBundle(it) }
+      ?.let { AdsLoader.State.CREATOR.fromBundle(it) }
   }
 
   override fun onResume() {
@@ -61,13 +61,15 @@ class ImaServerAdsActivity : AppCompatActivity() {
     )
   }
 
-  override fun onPause() {
-    stopPlaying()
-    super.onPause()
-  }
+//  override fun onPause() {
+//    stopPlaying()
+//    super.onPause()
+//  }
 
   @OptIn(UnstableApi::class)
   override fun onSaveInstanceState(outState: Bundle, outPersistentState: PersistableBundle) {
+    stopPlaying()
+    adsLoaderState = adsLoader?.release()
     adsLoaderState?.let {
       outState.putBundle(EXTRA_ADS_LOADER_STATE, it.toBundle())
     }
@@ -77,10 +79,10 @@ class ImaServerAdsActivity : AppCompatActivity() {
 
   @OptIn(UnstableApi::class)
   private fun createAdsLoaderIfNull(
-    state: ImaServerSideAdInsertionMediaSource.AdsLoader.State?,
+    state: AdsLoader.State?,
     playerView: PlayerView
-  ): ImaServerSideAdInsertionMediaSource.AdsLoader {
-    return ImaServerSideAdInsertionMediaSource.AdsLoader.Builder(this, playerView)
+  ): AdsLoader {
+    return AdsLoader.Builder(this, playerView)
       .apply { state?.let { adsLoaderState = it } }
       .build()
   }
@@ -88,7 +90,7 @@ class ImaServerAdsActivity : AppCompatActivity() {
   @OptIn(UnstableApi::class)
   private fun startPlaying(
     adTagUri: String,
-    adsLoader: ImaServerSideAdInsertionMediaSource.AdsLoader
+    adsLoader: AdsLoader
   ) {
     player = if (player != null) {
       stopPlaying()

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaServerAdsActivity.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaServerAdsActivity.kt
@@ -1,0 +1,167 @@
+package com.mux.stats.muxdatasdkformedia3.examples.ima
+
+import android.net.Uri
+import android.os.Bundle
+import android.os.PersistableBundle
+import android.util.Log
+import android.view.View
+import android.widget.Toast
+import androidx.annotation.OptIn
+import androidx.appcompat.app.AppCompatActivity
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaItem.AdsConfiguration
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.ima.ImaServerSideAdInsertionMediaSource
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.ui.PlayerView
+import com.mux.stats.muxdatasdkformedia3.Constants
+import com.mux.stats.muxdatasdkformedia3.databinding.ActivityPlayerBinding
+import com.mux.stats.sdk.core.model.CustomerData
+import com.mux.stats.sdk.core.model.CustomerPlayerData
+import com.mux.stats.sdk.core.model.CustomerVideoData
+import com.mux.stats.sdk.core.model.CustomerViewData
+import com.mux.stats.sdk.muxstats.MuxStatsSdkMedia3
+import com.mux.stats.sdk.muxstats.monitorWithMuxData
+
+class ImaServerAdsActivity : AppCompatActivity() {
+
+  private lateinit var view: ActivityPlayerBinding
+  private var player: Player? = null
+  private var muxStats: MuxStatsSdkMedia3<ExoPlayer>? = null
+  private var adsLoader: ImaServerSideAdInsertionMediaSource.AdsLoader? = null
+  private var adsLoaderState: ImaServerSideAdInsertionMediaSource.AdsLoader.State? = null
+
+  @OptIn(UnstableApi::class)
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    view = ActivityPlayerBinding.inflate(layoutInflater)
+    setContentView(view.root)
+
+    view.playerView.apply {
+      setShowBuffering(PlayerView.SHOW_BUFFERING_WHEN_PLAYING)
+    }
+    window.addFlags(View.KEEP_SCREEN_ON)
+
+    adsLoaderState = savedInstanceState?.getBundle(EXTRA_ADS_LOADER_STATE)
+      ?.let { ImaServerSideAdInsertionMediaSource.AdsLoader.State.CREATOR.fromBundle(it) }
+  }
+
+  override fun onResume() {
+    super.onResume()
+    startPlaying(
+      Constants.VOD_TEST_URL_DRAGON_WARRIOR_LADY,
+      Constants.AD_TAG_COMPLEX,
+      createAdsLoaderIfNull(adsLoaderState)
+    )
+  }
+
+  override fun onPause() {
+    stopPlaying()
+    super.onPause()
+  }
+
+  @OptIn(UnstableApi::class)
+  override fun onSaveInstanceState(outState: Bundle, outPersistentState: PersistableBundle) {
+    adsLoaderState?.let {
+      outState.putBundle(EXTRA_ADS_LOADER_STATE, it.toBundle())
+    }
+
+    super.onSaveInstanceState(outState, outPersistentState)
+  }
+
+  private fun createAdsLoaderIfNull(state: ImaServerSideAdInsertionMediaSource.AdsLoader.State?)
+  : ImaServerSideAdInsertionMediaSource.AdsLoader {
+  }
+
+  @OptIn(UnstableApi::class)
+  private fun startPlaying(
+    mediaUrl: String,
+    adTagUri: String,
+    adsLoader: ImaServerSideAdInsertionMediaSource.AdsLoader
+  ) {
+    player = if (player != null) {
+      stopPlaying()
+      player
+    } else {
+      createPlayer().also { newPlayer ->
+        muxStats = monitorPlayer(newPlayer)
+//        adsLoader = ImaAdsLoader.Builder(this)
+//          .monitorWith(
+//            muxStats = muxStats!!,
+//            customerAdErrorListener = { /*Optional parameter, your custom logic*/ },
+//            customerAdEventListener = { /*Optional parameter, your custom logic*/ },
+//          )
+//          .build()
+//          .apply { setPlayer(newPlayer) }
+
+        adsLoader.setPlayer(newPlayer)
+        view.playerView.player = newPlayer
+        newPlayer.setMediaItem(
+          MediaItem.Builder()
+            .setUri(Uri.parse(mediaUrl))
+            .setAdsConfiguration(AdsConfiguration.Builder(Uri.parse(adTagUri)).build())
+            .build()
+        )
+        newPlayer.prepare()
+        newPlayer.playWhenReady = true
+      }
+    } // if (player != null) else { ....
+
+  }
+
+  @OptIn(UnstableApi::class)
+  private fun stopPlaying() {
+    player?.let { oldPlayer ->
+      oldPlayer.stop()
+      oldPlayer.release()
+    }
+    // Make sure to release() your muxStats whenever the user is done with the player
+    muxStats?.release()
+  }
+
+  private fun monitorPlayer(player: ExoPlayer): MuxStatsSdkMedia3<ExoPlayer> {
+    // You can add your own data to a View, which will override any data we collect
+    val customerData = CustomerData(
+      CustomerPlayerData().apply { },
+      CustomerVideoData().apply {
+        title = "Mux Data SDK for Media3 Demo"
+      },
+      CustomerViewData().apply { }
+    )
+
+    return player.monitorWithMuxData(
+      context = this,
+      envKey = Constants.MUX_DATA_ENV_KEY,
+      customerData = customerData,
+      playerView = view.playerView
+    )
+  }
+
+  @OptIn(UnstableApi::class)
+  private fun createPlayer(): ExoPlayer {
+    val mediaSrcFactory = DefaultMediaSourceFactory(DefaultDataSource.Factory(this))
+      //.setLocalAdInsertionComponents({ adsLoader }, view.playerView)
+      .setServerSideAdInsertionMediaSourceFactory()
+
+    return ExoPlayer.Builder(this)
+      .setMediaSourceFactory(mediaSrcFactory)
+      .build()
+      .apply {
+        addListener(object : Player.Listener {
+          override fun onPlayerError(error: PlaybackException) {
+            Log.e(javaClass.simpleName, "player error!", error)
+            Toast.makeText(this@ImaServerAdsActivity, error.localizedMessage, Toast.LENGTH_SHORT)
+              .show()
+          }
+        })
+      }
+  }
+
+  companion object {
+    const val EXTRA_ADS_LOADER_STATE = "ads loader state"
+  }
+}

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaServerAdsActivity.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaServerAdsActivity.kt
@@ -83,13 +83,12 @@ class ImaServerAdsActivity : AppCompatActivity() {
   private fun createAdsLoaderIfNull(
     state: AdsLoader.State?,
     playerView: PlayerView,
-    muxStats: MuxStatsSdkMedia3<*>,
   ): AdsLoader {
     return adsLoader
       ?: AdsLoader.Builder(this, playerView)
         .apply { state?.let { adsLoaderState = it } }
         .monitorWith(
-          { muxStats },
+          { muxStats }, // This is safe, will only be called while playing
           { /*your ad event handling here*/ },
           { /*your ad error handling here*/ },
         )
@@ -105,7 +104,7 @@ class ImaServerAdsActivity : AppCompatActivity() {
       stopPlaying()
       player
     } else {
-      @Suppress("NAME_SHADOWING") val adsLoader = adsLoader ?: createAdsLoaderIfNull(adsLoaderState, view.playerView, muxStats!!)
+      @Suppress("NAME_SHADOWING") val adsLoader = adsLoader ?: createAdsLoaderIfNull(adsLoaderState, view.playerView)
       createPlayer(adsLoader).also { newPlayer ->
         muxStats = monitorPlayer(newPlayer)
         view.playerView.player = newPlayer

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaServerAdsActivity.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaServerAdsActivity.kt
@@ -89,7 +89,7 @@ class ImaServerAdsActivity : AppCompatActivity() {
       ?: AdsLoader.Builder(this, playerView)
         .apply { state?.let { adsLoaderState = it } }
         .monitorWith(
-          muxStats,
+          { muxStats },
           { /*your ad event handling here*/ },
           { /*your ad error handling here*/ },
         )

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaServerAdsActivity.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaServerAdsActivity.kt
@@ -46,6 +46,8 @@ class ImaServerAdsActivity : AppCompatActivity() {
 
     view.playerView.apply {
       setShowBuffering(PlayerView.SHOW_BUFFERING_WHEN_PLAYING)
+      setControllerHideDuringAds(false)
+      controllerAutoShow = true
     }
     window.addFlags(View.KEEP_SCREEN_ON)
 

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaServerAdsActivity.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaServerAdsActivity.kt
@@ -60,7 +60,7 @@ class ImaServerAdsActivity : AppCompatActivity() {
     super.onResume()
     startPlaying(
       Constants.AD_TAG_COMPLEX,
-      createAdsLoaderIfNull(adsLoaderState, view.playerView, muxStats!!)
+      null
     )
   }
 
@@ -99,12 +99,13 @@ class ImaServerAdsActivity : AppCompatActivity() {
   @OptIn(UnstableApi::class)
   private fun startPlaying(
     adTagUri: String,
-    adsLoader: AdsLoader
+    adsLoader: AdsLoader?
   ) {
     player = if (player != null) {
       stopPlaying()
       player
     } else {
+      @Suppress("NAME_SHADOWING") val adsLoader = adsLoader ?: createAdsLoaderIfNull(adsLoaderState, view.playerView, muxStats!!)
       createPlayer(adsLoader).also { newPlayer ->
         muxStats = monitorPlayer(newPlayer)
         view.playerView.player = newPlayer

--- a/app/src/main/res/layout/activity_player_ssai.xml
+++ b/app/src/main/res/layout/activity_player_ssai.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:context=".examples.basic.BasicPlayerActivity">
+
+    <androidx.media3.ui.PlayerView
+        android:id="@+id/player_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        />
+
+    <Button
+        android:id="@+id/skip_ad"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Skip Ad"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="@id/player_view"
+        app:layout_constraintTop_toTopOf="@id/player_view"
+        app:layout_constraintBottom_toBottomOf="@id/player_view"
+        tools:visibility="visible"
+        />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -91,16 +91,19 @@ dependencies {
   debugImplementation project(':library')
   
   // note- 3.30.0 and 3.30.1 are marked as broken by google, so don't use
-  api 'com.google.ads.interactivemedia.v3:interactivemedia:3.29.0'
+//  api 'com.google.ads.interactivemedia.v3:interactivemedia:3.29.0'
   // implementation is used so it doesn't pollute customers namespace
   implementation "com.mux:utils-kt:$coreVersion"
 
   //noinspection GradleDependency
   at_1_0Api "androidx.media3:media3-exoplayer-ima:1.0.0"
+  at_1_0Api "androidx.media3:media3-exoplayer:1.0.0"
   //noinspection GradleDependency
-  at_1_1Api "androidx.media3:media3-exoplayer-ima:1.1.0"
+  at_1_1Api "androidx.media3:media3-exoplayer-ima:1.1.1"
   //noinspection GradleDependency
-  at_latestApi "androidx.media3:media3-exoplayer-ima:1.1.0"
+  at_1_1Api "androidx.media3:media3-exoplayer:1.1.1"
+  at_latestApi "androidx.media3:media3-exoplayer-ima:1.1.1"
+  at_latestApi "androidx.media3:media3-exoplayer:1.1.1"
 
   implementation 'androidx.core:core-ktx:1.10.1'
   implementation 'androidx.appcompat:appcompat:1.6.1'

--- a/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/ImaAdsLoaderExt.kt
+++ b/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/ImaAdsLoaderExt.kt
@@ -25,7 +25,7 @@ fun ImaAdsLoader.Builder.monitorWith(
   customerAdErrorListener: AdErrorListener = AdErrorListener { },
 ): ImaAdsLoader.Builder {
   val adsListener = MuxImaAdsListener.newListener(
-    muxStats,
+    { muxStats },
     customerAdEventListener,
     customerAdErrorListener
   )

--- a/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/MuxImaAdsListener.kt
+++ b/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/MuxImaAdsListener.kt
@@ -1,6 +1,5 @@
 package com.mux.stats.sdk.media3_ima
 
-import android.util.Log
 import androidx.media3.common.Player
 import com.google.ads.interactivemedia.v3.api.Ad
 import com.google.ads.interactivemedia.v3.api.AdErrorEvent
@@ -8,7 +7,6 @@ import com.google.ads.interactivemedia.v3.api.AdErrorEvent.AdErrorListener
 import com.google.ads.interactivemedia.v3.api.AdEvent
 import com.google.ads.interactivemedia.v3.api.AdEvent.AdEventListener
 import com.mux.android.util.oneOf
-import com.mux.android.util.weak
 import com.mux.stats.sdk.core.events.playback.*
 import com.mux.stats.sdk.core.model.AdData
 import com.mux.stats.sdk.core.model.ViewData
@@ -85,17 +83,13 @@ class MuxImaAdsListener private constructor(
    * @param adEvent
    */
   override fun onAdEvent(adEvent: AdEvent) {
-    Log.d("ARGG", "onAdEvent: adEvent type ${adEvent.type.name}")
     exoPlayer?.let { player ->
-//      Log.d("ARGG", "onAdEvent: handling event with exoplayer $player")
-//      Log.d("ARGG", "onAdEvent: handling event with adCollector $adCollector")
       when (adEvent.type) {
         AdEvent.AdEventType.LOADED -> {}
         AdEvent.AdEventType.CONTENT_PAUSE_REQUESTED, // for CSAI
         AdEvent.AdEventType.AD_PERIOD_STARTED // for SSAI
         -> {
           @Suppress("RedundantNullableReturnType") val ad: Ad? = adEvent.ad
-//          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
           // Send pause event if we are currently playing or preparing to play content
           if (adCollector?.muxPlayerState.oneOf(MuxPlayerState.PLAY, MuxPlayerState.PLAYING)) {
             adCollector?.onPausedForAds()
@@ -115,7 +109,6 @@ class MuxImaAdsListener private constructor(
           // On the first STARTED, do not send AdPlay, as it was handled in
           // CONTENT_PAUSE_REQUESTED
           @Suppress("RedundantNullableReturnType") val ad: Ad? = adEvent.ad
-//          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
           if (sendPlayOnStarted) {
             dispatchAdPlaybackEvent(AdPlayEvent(null), ad)
           } else {
@@ -126,7 +119,6 @@ class MuxImaAdsListener private constructor(
 
         AdEvent.AdEventType.FIRST_QUARTILE -> {
           @Suppress("RedundantNullableReturnType") val ad: Ad? = adEvent.ad
-//          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
           dispatchAdPlaybackEvent(
             AdFirstQuartileEvent(null),
             ad
@@ -135,14 +127,12 @@ class MuxImaAdsListener private constructor(
 
         AdEvent.AdEventType.MIDPOINT -> {
           @Suppress("RedundantNullableReturnType") val ad: Ad? = adEvent.ad
-//          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
           dispatchAdPlaybackEvent(AdMidpointEvent(null), ad)
         }
 
         AdEvent.AdEventType.THIRD_QUARTILE -> {
           @Suppress("RedundantNullableReturnType") // can be null during ssai
           val ad: Ad? = adEvent.ad
-//          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
           dispatchAdPlaybackEvent(
             AdThirdQuartileEvent(null),
             ad
@@ -152,7 +142,6 @@ class MuxImaAdsListener private constructor(
         AdEvent.AdEventType.COMPLETED -> {
           @Suppress("RedundantNullableReturnType") // can be null during ssai
           val ad: Ad? = adEvent.ad
-//          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
           dispatchAdPlaybackEvent(AdEndedEvent(null), ad)
         }
 
@@ -161,7 +150,6 @@ class MuxImaAdsListener private constructor(
         -> {
           @Suppress("RedundantNullableReturnType") // can be null during ssai
           val ad: Ad? = adEvent.ad
-//          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
           dispatchAdPlaybackEvent(AdBreakEndEvent(null), ad)
           // ExoPlayer state doesn't change for client ads so fill in the blanks
           val willPlayImmediately = player.playWhenReady
@@ -174,7 +162,6 @@ class MuxImaAdsListener private constructor(
           if (player.playWhenReady || player.currentPosition != 0L) {
             @Suppress("RedundantNullableReturnType") // can be null during ssai
             val ad: Ad? = adEvent.ad
-//            Log.d("ARGG", "onAdEvent: Ad is ${ad}")
             dispatchAdPlaybackEvent(AdPauseEvent(null), ad)
           } else {
 
@@ -184,7 +171,6 @@ class MuxImaAdsListener private constructor(
         AdEvent.AdEventType.RESUMED -> {
           @Suppress("RedundantNullableReturnType") // can be null during ssai
           val ad: Ad? = adEvent.ad
-//          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
           if (missingAdBreakStartEvent) {
             // This is special case when we have ad preroll and play when ready is set to false
             // in that case we need to dispatch AdBreakStartEvent first and resume the playback.

--- a/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/MuxImaAdsListener.kt
+++ b/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/MuxImaAdsListener.kt
@@ -87,13 +87,13 @@ class MuxImaAdsListener private constructor(
   override fun onAdEvent(adEvent: AdEvent) {
     Log.d("ARGG", "onAdEvent: adEvent type ${adEvent.type.name}")
     exoPlayer?.let { player ->
-      Log.d("ARGG", "onAdEvent: handling event with exoplayer $player")
-      Log.d("ARGG", "onAdEvent: handling event with adCollector $adCollector")
+//      Log.d("ARGG", "onAdEvent: handling event with exoplayer $player")
+//      Log.d("ARGG", "onAdEvent: handling event with adCollector $adCollector")
       when (adEvent.type) {
         AdEvent.AdEventType.LOADED -> {}
         AdEvent.AdEventType.CONTENT_PAUSE_REQUESTED -> {
           @Suppress("RedundantNullableReturnType") val ad: Ad? = adEvent.ad
-          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
+//          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
           // Send pause event if we are currently playing or preparing to play content
           if (adCollector?.muxPlayerState.oneOf(MuxPlayerState.PLAY, MuxPlayerState.PLAYING)) {
             adCollector?.onPausedForAds()
@@ -113,7 +113,7 @@ class MuxImaAdsListener private constructor(
           // On the first STARTED, do not send AdPlay, as it was handled in
           // CONTENT_PAUSE_REQUESTED
           @Suppress("RedundantNullableReturnType") val ad: Ad? = adEvent.ad
-          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
+//          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
           if (sendPlayOnStarted) {
             dispatchAdPlaybackEvent(AdPlayEvent(null), ad)
           } else {
@@ -124,7 +124,7 @@ class MuxImaAdsListener private constructor(
 
         AdEvent.AdEventType.FIRST_QUARTILE -> {
           @Suppress("RedundantNullableReturnType") val ad: Ad? = adEvent.ad
-          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
+//          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
           dispatchAdPlaybackEvent(
             AdFirstQuartileEvent(null),
             ad
@@ -133,14 +133,14 @@ class MuxImaAdsListener private constructor(
 
         AdEvent.AdEventType.MIDPOINT -> {
           @Suppress("RedundantNullableReturnType") val ad: Ad? = adEvent.ad
-          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
+//          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
           dispatchAdPlaybackEvent(AdMidpointEvent(null), ad)
         }
 
         AdEvent.AdEventType.THIRD_QUARTILE -> {
           @Suppress("RedundantNullableReturnType") // can be null during ssai
           val ad: Ad? = adEvent.ad
-          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
+//          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
           dispatchAdPlaybackEvent(
             AdThirdQuartileEvent(null),
             ad
@@ -150,14 +150,14 @@ class MuxImaAdsListener private constructor(
         AdEvent.AdEventType.COMPLETED -> {
           @Suppress("RedundantNullableReturnType") // can be null during ssai
           val ad: Ad? = adEvent.ad
-          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
+//          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
           dispatchAdPlaybackEvent(AdEndedEvent(null), ad)
         }
 
         AdEvent.AdEventType.CONTENT_RESUME_REQUESTED -> {
           @Suppress("RedundantNullableReturnType") // can be null during ssai
           val ad: Ad? = adEvent.ad
-          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
+//          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
           dispatchAdPlaybackEvent(AdBreakEndEvent(null), ad)
           // ExoPlayer state doesn't change for client ads so fill in the blanks
           val willPlayImmediately = player.playWhenReady
@@ -170,7 +170,7 @@ class MuxImaAdsListener private constructor(
           if (player.playWhenReady || player.currentPosition != 0L) {
             @Suppress("RedundantNullableReturnType") // can be null during ssai
             val ad: Ad? = adEvent.ad
-            Log.d("ARGG", "onAdEvent: Ad is ${ad}")
+//            Log.d("ARGG", "onAdEvent: Ad is ${ad}")
             dispatchAdPlaybackEvent(AdPauseEvent(null), ad)
           } else {
 
@@ -180,7 +180,7 @@ class MuxImaAdsListener private constructor(
         AdEvent.AdEventType.RESUMED -> {
           @Suppress("RedundantNullableReturnType") // can be null during ssai
           val ad: Ad? = adEvent.ad
-          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
+//          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
           if (missingAdBreakStartEvent) {
             // This is special case when we have ad preroll and play when ready is set to false
             // in that case we need to dispatch AdBreakStartEvent first and resume the playback.

--- a/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/MuxImaAdsListener.kt
+++ b/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/MuxImaAdsListener.kt
@@ -209,12 +209,12 @@ class MuxImaAdsListener private constructor(
      */
     @JvmStatic
     fun newListener(
-      muxSdk: () -> MuxStatsSdkMedia3<*>?,
+      muxSdk: MuxStatsSdkMedia3<*>,
       customerAdEventListener: AdEventListener = AdEventListener { },
       customerAdErrorListener: AdErrorListener = AdErrorListener { },
     ): MuxImaAdsListener {
       return MuxImaAdsListener(
-        Provider(muxSdk),
+        Provider { muxSdk },
         customerAdEventListener,
         customerAdErrorListener
       )

--- a/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/MuxImaAdsListener.kt
+++ b/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/MuxImaAdsListener.kt
@@ -219,6 +219,21 @@ class MuxImaAdsListener private constructor(
         customerAdErrorListener
       )
     }
+      /**
+       * Creates a new [MuxImaAdsListener] based on the given [MuxStatsSdkMedia3]
+       */
+      @JvmStatic
+      fun newListener(
+        muxSdkProvider:() -> MuxStatsSdkMedia3<*>?,
+        customerAdEventListener: AdEventListener = AdEventListener { },
+        customerAdErrorListener: AdErrorListener = AdErrorListener { },
+      ): MuxImaAdsListener {
+        return MuxImaAdsListener(
+          Provider { muxSdkProvider() },
+          customerAdEventListener,
+          customerAdErrorListener
+        )
+      }
   }
 }
 

--- a/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/MuxImaAdsListener.kt
+++ b/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/MuxImaAdsListener.kt
@@ -193,7 +193,7 @@ class MuxImaAdsListener private constructor(
      */
     @JvmStatic
     fun newListener(
-      muxSdk: () -> MuxStatsSdkMedia3<*>,
+      muxSdk: () -> MuxStatsSdkMedia3<*>?,
       customerAdEventListener: AdEventListener = AdEventListener { },
       customerAdErrorListener: AdErrorListener = AdErrorListener { },
     ): MuxImaAdsListener {
@@ -206,7 +206,7 @@ class MuxImaAdsListener private constructor(
   }
 }
 
-private class Provider(sdkProvider: () -> MuxStatsSdkMedia3<*>) {
+private class Provider(sdkProvider: () -> MuxStatsSdkMedia3<*>?) {
   private val provider by weak(sdkProvider)
   val boundPlayer get() = provider?.invoke()?.boundPlayer
   val adCollector get() = provider?.invoke()?.adCollector

--- a/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/MuxImaAdsListener.kt
+++ b/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/MuxImaAdsListener.kt
@@ -91,7 +91,9 @@ class MuxImaAdsListener private constructor(
 //      Log.d("ARGG", "onAdEvent: handling event with adCollector $adCollector")
       when (adEvent.type) {
         AdEvent.AdEventType.LOADED -> {}
-        AdEvent.AdEventType.CONTENT_PAUSE_REQUESTED -> {
+        AdEvent.AdEventType.CONTENT_PAUSE_REQUESTED, // for CSAI
+        AdEvent.AdEventType.AD_PERIOD_STARTED // for SSAI
+        -> {
           @Suppress("RedundantNullableReturnType") val ad: Ad? = adEvent.ad
 //          Log.d("ARGG", "onAdEvent: Ad is ${ad}")
           // Send pause event if we are currently playing or preparing to play content
@@ -154,7 +156,9 @@ class MuxImaAdsListener private constructor(
           dispatchAdPlaybackEvent(AdEndedEvent(null), ad)
         }
 
-        AdEvent.AdEventType.CONTENT_RESUME_REQUESTED -> {
+        AdEvent.AdEventType.CONTENT_RESUME_REQUESTED, // for CSAI
+        AdEvent.AdEventType.AD_PERIOD_ENDED // for SSAI
+        -> {
           @Suppress("RedundantNullableReturnType") // can be null during ssai
           val ad: Ad? = adEvent.ad
 //          Log.d("ARGG", "onAdEvent: Ad is ${ad}")

--- a/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/ServerSideImaAdsLoaderExt.kt
+++ b/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/ServerSideImaAdsLoaderExt.kt
@@ -22,7 +22,7 @@ import com.mux.stats.sdk.muxstats.MuxStatsSdkMedia3
 @JvmSynthetic
 fun AdsLoader.Builder.monitorWith(
   // TODO: Add backward-compatible overload too
-  muxStatsProvider: () -> MuxStatsSdkMedia3<*>,
+  muxStatsProvider: () -> MuxStatsSdkMedia3<*>?,
   customerAdEventListener: AdEventListener = AdEventListener { },
   customerAdErrorListener: AdErrorListener = AdErrorListener { },
 ): AdsLoader.Builder {

--- a/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/ServerSideImaAdsLoaderExt.kt
+++ b/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/ServerSideImaAdsLoaderExt.kt
@@ -21,12 +21,13 @@ import com.mux.stats.sdk.muxstats.MuxStatsSdkMedia3
 @OptIn(UnstableApi::class)
 @JvmSynthetic
 fun AdsLoader.Builder.monitorWith(
-  muxStats: MuxStatsSdkMedia3<*>,
+  // TODO: Add backward-compatible overload too
+  muxStatsProvider: () -> MuxStatsSdkMedia3<*>,
   customerAdEventListener: AdEventListener = AdEventListener { },
   customerAdErrorListener: AdErrorListener = AdErrorListener { },
 ): AdsLoader.Builder {
   val adsListener = MuxImaAdsListener.newListener(
-    muxStats,
+    muxStatsProvider,
     customerAdEventListener,
     customerAdErrorListener
   )

--- a/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/ServerSideImaAdsLoaderExt.kt
+++ b/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/ServerSideImaAdsLoaderExt.kt
@@ -1,0 +1,38 @@
+package com.mux.stats.sdk.media3_ima
+
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ima.ImaAdsLoader
+import androidx.media3.exoplayer.ima.ImaServerSideAdInsertionMediaSource.AdsLoader
+import com.google.ads.interactivemedia.v3.api.AdErrorEvent.AdErrorListener
+import com.google.ads.interactivemedia.v3.api.AdEvent.AdEventListener
+import com.mux.stats.sdk.muxstats.MuxStatsSdkMedia3
+
+/**
+ * Monitors the [ImaAdsLoader] created by the given [ImaAdsLoader.Builder].
+ *
+ * Mux must take ownership of the [AdErrorListener] and [AdEventListener] for this ads loader, but
+ * you can provide your own listeners and logic using the provided optional params
+ *
+ * @param muxStats The [MuxStatsSdkMedia3] instance monitoring your player
+ * @param customerAdEventListener Optional. An [AdEventListener] with your apps custom ad-event handling
+ * @param customerAdErrorListener Optional. An [AdErrorListener] containing your app's ad-error handling
+ */
+@OptIn(UnstableApi::class)
+@JvmSynthetic
+fun AdsLoader.Builder.monitorWith(
+  muxStats: MuxStatsSdkMedia3<*>,
+  customerAdEventListener: AdEventListener = AdEventListener { },
+  customerAdErrorListener: AdErrorListener = AdErrorListener { },
+): AdsLoader.Builder {
+  val adsListener = MuxImaAdsListener.newListener(
+    muxStats,
+    customerAdEventListener,
+    customerAdErrorListener
+  )
+
+  setAdEventListener(adsListener)
+  setAdErrorListener(adsListener)
+
+  return this
+}

--- a/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/ServerSideImaAdsLoaderExt.kt
+++ b/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/ServerSideImaAdsLoaderExt.kt
@@ -14,14 +14,13 @@ import com.mux.stats.sdk.muxstats.MuxStatsSdkMedia3
  * Mux must take ownership of the [AdErrorListener] and [AdEventListener] for this ads loader, but
  * you can provide your own listeners and logic using the provided optional params
  *
- * @param muxStats The [MuxStatsSdkMedia3] instance monitoring your player
+ * @param muxStatsProvider Provides [MuxStatsSdkMedia3] instance for monitoring your player.
  * @param customerAdEventListener Optional. An [AdEventListener] with your apps custom ad-event handling
  * @param customerAdErrorListener Optional. An [AdErrorListener] containing your app's ad-error handling
  */
 @OptIn(UnstableApi::class)
 @JvmSynthetic
 fun AdsLoader.Builder.monitorWith(
-  // TODO: Add backward-compatible overload too
   muxStatsProvider: () -> MuxStatsSdkMedia3<*>?,
   customerAdEventListener: AdEventListener = AdEventListener { },
   customerAdErrorListener: AdErrorListener = AdErrorListener { },

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -83,7 +83,7 @@ muxDistribution {
     inceptionYear = "2022"
     url = "https://github.com/muxinc/mux-stats-sdk-media3"
     organization {
-      name =  "Mux, Inc"
+      name = "Mux, Inc"
       url = "https://www.mux.com"
     }
     developers {


### PR DESCRIPTION
SSAI requires access to the player & player view in an odd way, which means there's a dependency loop we can't break without a provider. SSAI users will have to use a special API where they provide their `muxStats` asynchrnously