### PR TITLE
fix: bandwidth metrics not reported in some cases

### DIFF
--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
@@ -96,11 +96,9 @@ open class ExoPlayerBinding : MuxPlayerAdapter.PlayerBinding<ExoPlayer> {
 @OptIn(UnstableApi::class)
 private class MuxAnalyticsListener(
   player: ExoPlayer,
-  bandwidthMetrics: BandwidthMetricDispatcher,
+  val bandwidthMetrics: BandwidthMetricDispatcher,
   val collector: MuxStateCollector,
 ) : AnalyticsListener {
-
-  private val bandwidthMetrics by weak(bandwidthMetrics)
   private val player by weak(player)
 
   override fun onPlayWhenReadyChanged(

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/bandwidth/BandwidthMetrics.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/bandwidth/BandwidthMetrics.kt
@@ -411,7 +411,9 @@ internal class BandwidthMetricDispatcher(
       }
 
       val headerValues: List<String> = responseHeaders[headerName]!!
-      if (headerValues.size == 1) {
+      if (headerValues.isEmpty()) {
+        headers[headerName] = ""
+      } else if (headerValues.size == 1) {
         headers[headerName] = headerValues[0]
       } else if (headerValues.size > 1) {
         // In the case that there is more than one header, we squash

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/bandwidth/BandwidthMetrics.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/bandwidth/BandwidthMetrics.kt
@@ -28,11 +28,13 @@ import java.util.regex.Pattern
  * point both HLS and DASH segments are processed in same way so all metrics are collected here.
  */
 internal open class BandwidthMetrics(
-  private val player: ExoPlayer,
+  player: ExoPlayer,
   private val collector: MuxStateCollector
 ) {
   /** Available qualities. */
   var availableTracks: List<Group>? = null
+
+  private val player by weak(player)
 
   /**
    * Each segment that started loading is stored here until the segment ceases loading.
@@ -89,12 +91,14 @@ internal open class BandwidthMetrics(
   ): BandwidthMetricData {
     // Populate segment time details.
     synchronized(currentTimelineWindow) {
-      try {
-        player.currentTimeline
-          .getWindow(player.currentWindowIndex, currentTimelineWindow)
-      } catch (e: Exception) {
-        // Failed to obtain data, ignore, we will get it on next call
-        MuxLogger.exception(e, "BandwidthMetrics", "Failed to get current timeline")
+      player?.let { safePlayer ->
+        try {
+          safePlayer.currentTimeline
+            .getWindow(safePlayer.currentWindowIndex, currentTimelineWindow)
+        } catch (e: Exception) {
+          // Failed to obtain data, ignore, we will get it on next call
+          MuxLogger.exception(e, "BandwidthMetrics", "Failed to get current timeline")
+        }
       }
     }
     val segmentData = BandwidthMetricData()


### PR DESCRIPTION
Since the only reference to `BandwidthMetrics` is in `ExoAnalyticsListener`, we don't want it to be `weak`.

Since the `player` inside `BandwidthMetrics` is `weak` we don't need to worry about retaining `BandwidthMetrics`. There *does* mean an instance may be retained inside Java Core when a customer fails to call `release()`, but it will *not* result in leaking an `ExoPlayer` or a `Context` because the dispatcher doesn't hold strong refs to them.