### PR TITLE
Releases/v1.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 allprojects {
   project.ext {
-    coreVersion = '1.1.0'
+    coreVersion = '1.1.1'
   }
 
   tasks.withType(DokkaTaskPartial.class) {

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -114,9 +114,6 @@ dependencies {
   //noinspection GradleDependency
   at_latestCompileOnly "androidx.media3:media3-exoplayer-hls:1.2.0"
 
-  implementation 'androidx.core:core-ktx:1.12.0'
-  implementation 'androidx.appcompat:appcompat:1.6.1'
-  implementation 'com.google.android.material:material:1.10.0'
   testImplementation 'junit:junit:4.13.2'
   androidTestImplementation 'androidx.test.ext:junit:1.1.5'
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/MuxImaAdsListener.kt
+++ b/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/MuxImaAdsListener.kt
@@ -59,17 +59,19 @@ class MuxImaAdsListener private constructor(
   private fun setupAdViewData(event: MuxAdEvent, ad: Ad?) {
     val viewData = ViewData()
     val adData = AdData();
-    if (adCollector?.playbackPositionMillis == 0L) {
-      if (ad != null) {
-        viewData.viewPrerollAdId = ad.adId
-        viewData.viewPrerollCreativeId = ad.creativeId
-
-        exoPlayer?.getAdTagUrl()?.let { adData.adTagUrl = it }
-        ad.adId?.let { adData.adId = it }
-        ad.creativeId?.let { adData.adCreativeId = it }
-        @Suppress("DEPRECATION") // This is only deprecated on android, we need consistency
-        ad.universalAdIdValue?.let { adData.adUniversalId = it }
+    if (ad != null) {
+      adCollector?.let {
+        if (it.playbackPositionMillis < 1000L) {
+          viewData.viewPrerollAdId = ad.adId
+          viewData.viewPrerollCreativeId = ad.creativeId
+        }
       }
+
+      exoPlayer?.getAdTagUrl()?.let { adData.adTagUrl = it }
+      ad.adId?.let { adData.adId = it }
+      ad.creativeId?.let { adData.adCreativeId = it }
+      @Suppress("DEPRECATION") // This is only deprecated on android, we need consistency
+      ad.universalAdIdValue?.let { adData.adUniversalId = it }
     }
     event.viewData = viewData
     event.adData = adData;


### PR DESCRIPTION
## Fixes

* fix: populate ad data even for non-preroll ads (#60)
* fix: seeking time included in time-to-first frame if user seeks before play starts

## Improvements

* remove extraneous androidx deps from the exoplayer lib (they are still required if using IMA) (#62)


Co-authored-by: Emily Dixon <edixon@mux.com>
Co-authored-by: GitHub <noreply@github.com>