### PR TITLE
Releases/v1.3.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,12 +22,13 @@ android {
 
   flavorDimensions = ["media3"]
   productFlavors {
+    At_latest { dimension "media3" }
     // This module does not currently need different src sets for different media3 versions.
     // We still need to declare different flavors so we can create version-specific variants
     at_1_0 { dimension "media3" }
     at_1_1 { dimension "media3" }
     at_1_2 { dimension "media3" }
-    at_latest { dimension "media3" }
+    at_1_3 { dimension "media3" }
   }
 
   buildTypes {
@@ -101,14 +102,22 @@ dependencies {
   at_1_2Implementation "androidx.media3:media3-exoplayer-dash:1.2.0"
   at_1_2Implementation "androidx.media3:media3-exoplayer-hls:1.2.0"
   at_1_2Implementation "androidx.media3:media3-exoplayer-rtsp:1.2.0"
+  
+  at_1_3Implementation "androidx.media3:media3-exoplayer:1.3.0"
+  at_1_3Implementation "androidx.media3:media3-session:1.3.0"
+  at_1_3Implementation "androidx.media3:media3-ui:1.3.0"
+  at_1_3Implementation "androidx.media3:media3-exoplayer-ima:1.3.0"
+  at_1_3Implementation "androidx.media3:media3-exoplayer-dash:1.3.0"
+  at_1_3Implementation "androidx.media3:media3-exoplayer-hls:1.3.0"
+  at_1_3Implementation "androidx.media3:media3-exoplayer-rtsp:1.3.0"
 
-  at_latestImplementation "androidx.media3:media3-exoplayer:1.2.0"
-  at_latestImplementation "androidx.media3:media3-session:1.2.0"
-  at_latestImplementation "androidx.media3:media3-ui:1.2.0"
-  at_latestImplementation "androidx.media3:media3-exoplayer-ima:1.2.0"
-  at_latestImplementation "androidx.media3:media3-exoplayer-dash:1.2.0"
-  at_latestImplementation "androidx.media3:media3-exoplayer-hls:1.2.0"
-  at_latestImplementation "androidx.media3:media3-exoplayer-rtsp:1.2.0"
+  At_latestImplementation "androidx.media3:media3-exoplayer:1.3.1"
+  At_latestImplementation "androidx.media3:media3-session:1.3.1"
+  At_latestImplementation "androidx.media3:media3-ui:1.3.1"
+  At_latestImplementation "androidx.media3:media3-exoplayer-ima:1.3.1"
+  At_latestImplementation "androidx.media3:media3-exoplayer-dash:1.3.1"
+  At_latestImplementation "androidx.media3:media3-exoplayer-hls:1.3.1"
+  At_latestImplementation "androidx.media3:media3-exoplayer-rtsp:1.3.1"
 
   implementation 'androidx.core:core-ktx:1.12.0'
   implementation 'androidx.appcompat:appcompat:1.6.1'

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -20,10 +20,11 @@ android {
   productFlavors {
     // This module does not currently need different src sets for different media3 versions.
     // We still need to declare different flavors so we can create version-specific variants
+    At_latest { dimension "media3" }
     at_1_0 { dimension "media3" }
     at_1_1 { dimension "media3" }
     at_1_2 { dimension "media3" }
-    at_latest { dimension "media3" }
+    at_1_3 { dimension "media3" }
   }
 
   buildTypes {
@@ -110,9 +111,14 @@ dependencies {
   at_1_2CompileOnly "androidx.media3:media3-exoplayer-hls:1.2.0"
 
   //noinspection GradleDependency
-  at_latestApi "androidx.media3:media3-exoplayer:1.2.0"
+  at_1_3Api "androidx.media3:media3-exoplayer:1.3.0"
   //noinspection GradleDependency
-  at_latestCompileOnly "androidx.media3:media3-exoplayer-hls:1.2.0"
+  at_1_3CompileOnly "androidx.media3:media3-exoplayer-hls:1.3.0"
+
+  //noinspection GradleDependency
+  At_latestApi "androidx.media3:media3-exoplayer:1.3.0"
+  //noinspection GradleDependency
+  At_latestCompileOnly "androidx.media3:media3-exoplayer-hls:1.3.0"
 
   testImplementation 'junit:junit:4.13.2'
   androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/internal/HlsUtils.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/internal/HlsUtils.kt
@@ -3,6 +3,7 @@ package com.mux.stats.sdk.muxstats.internal
 import androidx.annotation.OptIn
 import androidx.media3.common.Timeline
 import androidx.media3.common.Timeline.Window
+import androidx.media3.common.util.Log
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.hls.HlsManifest
 import com.mux.stats.sdk.core.util.MuxLogger
@@ -18,7 +19,13 @@ private val hlsExtensionAvailable: Boolean by lazy {
   try {
     Class.forName(HlsManifest::class.java.canonicalName!!)
     true
-  } catch (e: Exception) {
+  } catch (e: ClassNotFoundException) {
+    MuxLogger.w("isHlsExtensionAvailable", "HLS extension not found. Some features may not work")
+    false
+  } catch (e: LinkageError) {
+    MuxLogger.w("isHlsExtensionAvailable", "HLS extension not found. Some features may not work")
+    false
+  } catch (e: ExceptionInInitializerError) {
     MuxLogger.w("isHlsExtensionAvailable", "HLS extension not found. Some features may not work")
     false
   }

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -20,10 +20,11 @@ android {
   productFlavors {
     // This module does not currently need different src sets for different media3 versions.
     // We still need to declare different flavors so we can create version-specific variants
+    At_latest { dimension "media3" }
     at_1_0 { dimension "media3" }
     at_1_1 { dimension "media3" }
     at_1_2 { dimension "media3" }
-    at_latest { dimension "media3" }
+    at_1_3 { dimension "media3" }
   }
 
   buildTypes {
@@ -107,8 +108,12 @@ dependencies {
   at_1_2Api "androidx.media3:media3-exoplayer-ima:1.2.0"
   //noinspection GradleDependency
   at_1_2Api "androidx.media3:media3-exoplayer:1.2.0"
-  at_latestApi "androidx.media3:media3-exoplayer-ima:1.2.0"
-  at_latestApi "androidx.media3:media3-exoplayer:1.2.0"
+  //noinspection GradleDependency
+  at_1_3Api "androidx.media3:media3-exoplayer-ima:1.3.0"
+  //noinspection GradleDependency
+  at_1_3Api "androidx.media3:media3-exoplayer:1.3.0"
+  At_latestApi "androidx.media3:media3-exoplayer-ima:1.3.0"
+  At_latestApi "androidx.media3:media3-exoplayer:1.3.0"
 
   implementation 'androidx.core:core-ktx:1.12.0'
   implementation 'androidx.appcompat:appcompat:1.6.1'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -18,6 +18,10 @@ android {
 
   flavorDimensions = ["media3"]
   productFlavors {
+    At_latest {
+      dimension "media3"
+      buildConfigField "String", "MEDIA3_VERSION", "\"1.3.x\""
+    }
     // This module does not currently need different src sets for different media3 versions.
     // We still need to declare different flavors so we can create version-specific variants
     at_1_0 {
@@ -32,9 +36,9 @@ android {
       dimension "media3"
       buildConfigField "String", "MEDIA3_VERSION", "\"1.2.x\""
     }
-    at_latest {
+    at_1_3 {
       dimension "media3"
-      buildConfigField "String", "MEDIA3_VERSION", "\"1.2.x\""
+      buildConfigField "String", "MEDIA3_VERSION", "\"1.3.x\""
     }
   }
 
@@ -110,7 +114,8 @@ dependencies {
   //noinspection GradleDependency
   at_1_1Api "androidx.media3:media3-common:1.1.0"
   at_1_2Api "androidx.media3:media3-common:1.2.0"
-  at_latestApi "androidx.media3:media3-common:1.2.0"
+  at_1_3Api "androidx.media3:media3-common:1.3.0"
+  At_latestApi "androidx.media3:media3-common:1.3.0"
 
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
 


### PR DESCRIPTION
## Updates
* update: Add support for media3 1.3.0 (#74)

## Fixes
* fix: reported app hang due to event handling during beacon dispatch 
* fix: crash when exoplayer HLS module not used (#75)

## Improvements
* Update Android Core to v1.2.1
* Update Java Core to v8.0.1

Co-authored-by: Emily Dixon <edixon@mux.com>
Co-authored-by: GitHub <noreply@github.com>