### PR TITLE
Update README with details for setting Media3 version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Add a dependency on this SDK
 api 'com.mux.stats.sdk.muxstats:data-media3:1.2.2'
 ```
 
+To include a specific version of the Media3 library, append `-at_x_y` to the artifact ID in the dependency. For example:
+
+```groovy
+api "com.mux.stats.sdk.muxstats:data-media3-at_1_1:1.2.2"
+```
+
 ### Monitor your player
 
 After you create your `Player` instance, monitor it with `monitorWithMuxData()`.


### PR DESCRIPTION
Updates the README with details on how to specify the Media3 version being used, independent of the Mux Data SDK version.