### PR TITLE
chore: fix multidex build for android APIs 19-20

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,7 +49,7 @@ android {
     jvmTarget = '1.8'
   }
   composeOptions {
-    kotlinCompilerExtensionVersion '1.5.10'
+    kotlinCompilerExtensionVersion '1.5.14'
   }
   packaging {
     resources {

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-  id 'com.android.application' version '8.3.1' apply false
-  id 'com.android.library' version '8.3.1' apply false
-  id 'org.jetbrains.kotlin.android' version '1.9.22' apply false
+  id 'com.android.application' version '8.4.1' apply false
+  id 'com.android.library' version '8.4.1' apply false
+  id 'org.jetbrains.kotlin.android' version '1.9.24' apply false
   id 'com.mux.gradle.android.mux-android-distribution' version '1.1.2' apply false
   id "org.jetbrains.dokka" version "1.6.10"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 allprojects {
   project.ext {
-    coreVersion = '1.2.0'
+    coreVersion = '1.2.2'
   }
 
   tasks.withType(DokkaTaskPartial.class) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-  id 'com.android.application' version '8.4.1' apply false
-  id 'com.android.library' version '8.4.1' apply false
-  id 'org.jetbrains.kotlin.android' version '1.9.24' apply false
+  id 'com.android.application' version '8.3.1' apply false
+  id 'com.android.library' version '8.3.1' apply false
+  id 'org.jetbrains.kotlin.android' version '1.9.22' apply false
   id 'com.mux.gradle.android.mux-android-distribution' version '1.1.2' apply false
   id "org.jetbrains.dokka" version "1.6.10"
 }

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -9,7 +9,7 @@ android {
   compileSdk 34
 
   defaultConfig {
-    minSdk 19
+    minSdk 16
     targetSdk 34
 
     // our deps almost blow the dex limit by themselves, media3 doc/examples all use multidex

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -9,8 +9,11 @@ android {
   compileSdk 34
 
   defaultConfig {
-    minSdk 16
+    minSdk 19
     targetSdk 34
+
+    // our deps almost blow the dex limit by themselves, media3 doc/examples all use multidex
+    multiDexEnabled true
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles "consumer-rules.pro"

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -115,14 +115,14 @@ dependencies {
   At_latestApi "androidx.media3:media3-exoplayer-ima:1.3.0"
   At_latestApi "androidx.media3:media3-exoplayer:1.3.0"
 
-  implementation 'androidx.core:core-ktx:1.13.1'
-  implementation 'androidx.appcompat:appcompat:1.7.0'
-  implementation 'com.google.android.material:material:1.12.0'
+  implementation 'androidx.core:core-ktx:1.12.0'
+  implementation 'androidx.appcompat:appcompat:1.6.1'
+  implementation 'com.google.android.material:material:1.10.0'
 
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'androidx.test.ext:junit:1.1.5'
-  testImplementation "io.mockk:mockk:1.13.9"
-  testImplementation 'org.robolectric:robolectric:4.11.1'
+  testImplementation "io.mockk:mockk:1.12.3"
+  testImplementation 'org.robolectric:robolectric:4.10.3'
 
   androidTestImplementation 'androidx.test.ext:junit:1.1.5'
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -10,7 +10,10 @@ android {
 
   defaultConfig {
     targetSdk 34
-    minSdk 16
+    minSdk 19
+
+    // our deps almost blow the dex limit by themselves, media3 doc/examples all use multidex
+    multiDexEnabled true
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles "consumer-rules.pro"
@@ -116,8 +119,6 @@ dependencies {
   At_latestApi "androidx.media3:media3-exoplayer:1.3.0"
 
   implementation 'androidx.core:core-ktx:1.12.0'
-  implementation 'androidx.appcompat:appcompat:1.6.1'
-  implementation 'com.google.android.material:material:1.10.0'
 
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'androidx.test.ext:junit:1.1.5'

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -10,7 +10,7 @@ android {
 
   defaultConfig {
     targetSdk 34
-    minSdk 19
+    minSdk 16
 
     // our deps almost blow the dex limit by themselves, media3 doc/examples all use multidex
     multiDexEnabled true

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -115,14 +115,14 @@ dependencies {
   At_latestApi "androidx.media3:media3-exoplayer-ima:1.3.0"
   At_latestApi "androidx.media3:media3-exoplayer:1.3.0"
 
-  implementation 'androidx.core:core-ktx:1.12.0'
-  implementation 'androidx.appcompat:appcompat:1.6.1'
-  implementation 'com.google.android.material:material:1.10.0'
+  implementation 'androidx.core:core-ktx:1.13.1'
+  implementation 'androidx.appcompat:appcompat:1.7.0'
+  implementation 'com.google.android.material:material:1.12.0'
 
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'androidx.test.ext:junit:1.1.5'
-  testImplementation "io.mockk:mockk:1.12.3"
-  testImplementation 'org.robolectric:robolectric:4.10.3'
+  testImplementation "io.mockk:mockk:1.13.9"
+  testImplementation 'org.robolectric:robolectric:4.11.1'
 
   androidTestImplementation 'androidx.test.ext:junit:1.1.5'
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -118,7 +118,7 @@ dependencies {
   At_latestApi "androidx.media3:media3-exoplayer-ima:1.3.0"
   At_latestApi "androidx.media3:media3-exoplayer:1.3.0"
 
-  implementation 'androidx.core:core-ktx:1.12.0'
+  implementation 'androidx.core:core-ktx:1.13.1'
 
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'androidx.test.ext:junit:1.1.5'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -9,7 +9,7 @@ android {
   compileSdk 34
 
   defaultConfig {
-    minSdk 16
+    minSdk 19
     targetSdk 34
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -9,7 +9,7 @@ android {
   compileSdk 34
 
   defaultConfig {
-    minSdk 19
+    minSdk 16
     targetSdk 34
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -121,8 +121,8 @@ dependencies {
 
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'androidx.test.ext:junit:1.1.5'
-  testImplementation "io.mockk:mockk:1.12.3"
-  testImplementation 'org.robolectric:robolectric:4.10.3'
+  testImplementation "io.mockk:mockk:1.13.9"
+  testImplementation 'org.robolectric:robolectric:4.11.1'
 
   androidTestImplementation 'androidx.test.ext:junit:1.1.5'
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -121,8 +121,8 @@ dependencies {
 
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'androidx.test.ext:junit:1.1.5'
-  testImplementation "io.mockk:mockk:1.13.9"
-  testImplementation 'org.robolectric:robolectric:4.11.1'
+  testImplementation "io.mockk:mockk:1.12.3"
+  testImplementation 'org.robolectric:robolectric:4.10.3'
 
   androidTestImplementation 'androidx.test.ext:junit:1.1.5'
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'


### PR DESCRIPTION
This is not customer-visible, but is definitely more correct. Their application build would resolve the `minSdk` to 19+ and enable multidex (one way or another) because it depends on media3. Us doing the same here simplifies our own build