### PR TITLE
fix: match media3's minSdk

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-  id 'com.android.application' version '8.4.1' apply false
-  id 'com.android.library' version '8.4.1' apply false
+  id 'com.android.application' version '8.4.2' apply false
+  id 'com.android.library' version '8.4.2' apply false
   id 'org.jetbrains.kotlin.android' version '1.9.24' apply false
   id 'com.mux.gradle.android.mux-android-distribution' version '1.1.2' apply false
   id "org.jetbrains.dokka" version "1.6.10"

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -9,7 +9,7 @@ android {
   compileSdk 34
 
   defaultConfig {
-    minSdk 16
+    minSdk 19
     targetSdk 34
 
     // our deps almost blow the dex limit by themselves, media3 doc/examples all use multidex

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -10,7 +10,7 @@ android {
 
   defaultConfig {
     targetSdk 34
-    minSdk 16
+    minSdk 19
 
     // our deps almost blow the dex limit by themselves, media3 doc/examples all use multidex
     multiDexEnabled true

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -9,7 +9,7 @@ android {
   compileSdk 34
 
   defaultConfig {
-    minSdk 16
+    minSdk 19
     targetSdk 34
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Affects certain local build tasks, such as making every package.

Customer builds shouldn't be affected. If they're overriding the minSdk from media3, the override would apply to us as well