### PR TITLE
feat: Handle nonfatal codec exceptions on API 21+

### DIFF
--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
@@ -22,7 +22,6 @@ import com.mux.stats.sdk.muxstats.internal.createErrorDataBinding
 import com.mux.stats.sdk.muxstats.internal.createExoSessionDataBinding
 import com.mux.stats.sdk.muxstats.internal.populateLiveStreamData
 import java.io.IOException
-import java.lang.Exception
 import java.util.regex.Pattern
 
 /**

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
@@ -22,6 +22,7 @@ import com.mux.stats.sdk.muxstats.internal.createErrorDataBinding
 import com.mux.stats.sdk.muxstats.internal.createExoSessionDataBinding
 import com.mux.stats.sdk.muxstats.internal.populateLiveStreamData
 import java.io.IOException
+import java.lang.Exception
 import java.util.regex.Pattern
 
 /**

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/internal/ErrorBinding.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/internal/ErrorBinding.kt
@@ -105,13 +105,7 @@ internal fun MuxStateCollector.handleExoPlaybackException(errorCode: Int, e: Exo
     ExoPlaybackException.TYPE_RENDERER -> {
       when (val rex = e.rendererException) {
         is MediaCodecRenderer.DecoderInitializationException -> {
-          if (rex.cause is MediaCodecUtil.DecoderQueryException) {
-            internalError(MuxErrorException(errorCode, "Unable to query device decoders"))
-          } else if (rex.secureDecoderRequired) {
-            internalError(MuxErrorException(errorCode, createErrorMessage(rex), rex.diagnosticInfo))
-          } else {
-            internalError(MuxErrorException(errorCode, createErrorMessage(rex), rex.diagnosticInfo))
-          }
+          internalError(MuxErrorException(errorCode, createErrorMessage(rex), rex.diagnosticInfo))
         }
 
         is MediaCodecDecoderException -> {

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/internal/ErrorBinding.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/internal/ErrorBinding.kt
@@ -105,7 +105,13 @@ internal fun MuxStateCollector.handleExoPlaybackException(errorCode: Int, e: Exo
     ExoPlaybackException.TYPE_RENDERER -> {
       when (val rex = e.rendererException) {
         is MediaCodecRenderer.DecoderInitializationException -> {
-          internalError(MuxErrorException(errorCode, createErrorMessage(rex), rex.diagnosticInfo))
+          if (rex.cause is MediaCodecUtil.DecoderQueryException) {
+            internalError(MuxErrorException(errorCode, "Unable to query device decoders"))
+          } else if (rex.secureDecoderRequired) {
+            internalError(MuxErrorException(errorCode, createErrorMessage(rex), rex.diagnosticInfo))
+          } else {
+            internalError(MuxErrorException(errorCode, createErrorMessage(rex), rex.diagnosticInfo))
+          }
         }
 
         is MediaCodecDecoderException -> {

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/internal/ErrorBinding.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/internal/ErrorBinding.kt
@@ -108,9 +108,17 @@ internal fun MuxStateCollector.handleExoPlaybackException(errorCode: Int, e: Exo
           if (rex.cause is MediaCodecUtil.DecoderQueryException) {
             internalError(MuxErrorException(errorCode, "Unable to query device decoders"))
           } else if (rex.secureDecoderRequired) {
-            internalError(MuxErrorException(errorCode, createErrorMessage(rex), rex.diagnosticInfo))
+            internalError(
+              MuxErrorException(
+                errorCode,
+                "No secure decoder for ${rex.mimeType}",
+                rex.diagnosticInfo
+              )
+            )
           } else {
-            internalError(MuxErrorException(errorCode, createErrorMessage(rex), rex.diagnosticInfo))
+            internalError(
+              MuxErrorException(errorCode, "No decoder for ${rex.mimeType}", rex.diagnosticInfo)
+            )
           }
         }
 


### PR DESCRIPTION
Reproducing this reliably might be hard. The causes of these errors seem to be related to the availability of device resources, which is why they are recoverable by resetting the codec. 

Causing the decoders to become unavailable on purpose might be tricky. We could try, eg, allocating a ton of `MediaCodec`s and seeing if we get failures like this eventually. There could be other ways to cause it from an app, but I'd need to research more