### PR TITLE
update minSdk to 21 for media3 v1.4+

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,11 +5,12 @@ plugins {
 
 android {
   namespace 'com.mux.stats.muxdatasdkformedia3'
-  compileSdk 34
+  compileSdk 35
 
   defaultConfig {
     applicationId "com.example.muxdatasdkformedia3"
-    targetSdk 34
+    //noinspection OldTargetApi
+    targetSdk 35
     minSdk 21
     versionCode 1
     versionName "1.0"

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -14,7 +14,6 @@ android {
 
   defaultConfig {
     minSdk 19
-    targetSdk 34
 
     // our deps almost blow the dex limit by themselves, media3 doc/examples all use multidex
     multiDexEnabled true
@@ -32,7 +31,10 @@ android {
     at_1_1 { dimension "media3" }
     at_1_2 { dimension "media3" }
     at_1_3 { dimension "media3" }
-    at_1_4 { dimension "media3" }
+    at_1_4 {
+      dimension "media3"
+      minSdk 21 // media3 has a minSdk of 21 since v1.4
+    }
   }
 
   buildTypes {

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -13,7 +13,7 @@ android {
   }
 
   defaultConfig {
-    minSdk 19
+    minSdk 21
 
     // our deps almost blow the dex limit by themselves, media3 doc/examples all use multidex
     multiDexEnabled true
@@ -27,13 +27,24 @@ android {
     // This module does not currently need different src sets for different media3 versions.
     // We still need to declare different flavors so we can create version-specific variants
     At_latest { dimension "media3" }
-    at_1_0 { dimension "media3" }
-    at_1_1 { dimension "media3" }
-    at_1_2 { dimension "media3" }
-    at_1_3 { dimension "media3" }
+    at_1_0 {
+     dimension "media3"
+      minSdk 19 // minSdk is 19 before 1.4
+     }
+    at_1_1 {
+     dimension "media3"
+      minSdk 19 // minSdk is 19 before 1.4
+     }
+    at_1_2 {
+     dimension "media3"
+      minSdk 19 // minSdk is 19 before 1.4
+     }
+    at_1_3 {
+     dimension "media3"
+      minSdk 19 // minSdk is 19 before 1.4
+     }
     at_1_4 {
       dimension "media3"
-      minSdk 21 // media3 has a minSdk of 21 since v1.4
     }
   }
 

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
   namespace 'com.mux.stats.sdk.muxstats.media3_exo'
-  compileSdk 34
+  compileSdk 35
 
   buildFeatures {
     buildConfig = true

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -13,7 +13,7 @@ android {
   }
 
   defaultConfig {
-    minSdk 19
+    minSdk 21
 
     // our deps almost blow the dex limit by themselves, media3 doc/examples all use multidex
     multiDexEnabled true
@@ -27,13 +27,24 @@ android {
     // This module does not currently need different src sets for different media3 versions.
     // We still need to declare different flavors so we can create version-specific variants
     At_latest { dimension "media3" }
-    at_1_0 { dimension "media3" }
-    at_1_1 { dimension "media3" }
-    at_1_2 { dimension "media3" }
-    at_1_3 { dimension "media3" }
+    at_1_0 {
+      dimension "media3"
+      minSdk 19 // minSdk is 19 before 1.4
+    }
+    at_1_1 {
+      dimension "media3"
+      minSdk 19 // minSdk is 19 before 1.4
+    }
+    at_1_2 {
+     dimension "media3"
+      minSdk 19 // minSdk is 19 before 1.4
+     }
+    at_1_3 {
+     dimension "media3"
+      minSdk 19 // minSdk is 19 before 1.4
+     }
     at_1_4 {
       dimension "media3"
-      minSdk 21 // media3 has a minSdk of 21 since v1.4
     }
   }
 

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -13,7 +13,6 @@ android {
   }
 
   defaultConfig {
-    targetSdk 34
     minSdk 19
 
     // our deps almost blow the dex limit by themselves, media3 doc/examples all use multidex
@@ -32,7 +31,10 @@ android {
     at_1_1 { dimension "media3" }
     at_1_2 { dimension "media3" }
     at_1_3 { dimension "media3" }
-    at_1_4 { dimension "media3" }
+    at_1_4 {
+      dimension "media3"
+      minSdk 21 // media3 has a minSdk of 21 since v1.4
+    }
   }
 
   buildTypes {

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
   namespace 'com.mux.stats.sdk.media3_ima'
-  compileSdk 34
+  compileSdk 35
 
   buildFeatures {
     buildConfig = true

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -13,7 +13,7 @@ android {
   }
 
   defaultConfig {
-    minSdk 19
+    minSdk 21
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles "consumer-rules.pro"
@@ -28,19 +28,22 @@ android {
     // We still need to declare different flavors so we can create version-specific variants
     at_1_0 {
       dimension "media3"
+      minSdk 19 // minSdk is 19 before 1.4
     }
     at_1_1 {
       dimension "media3"
+      minSdk 19 // minSdk is 19 before 1.4
     }
     at_1_2 {
       dimension "media3"
+      minSdk 19 // minSdk is 19 before 1.4
     }
     at_1_3 {
       dimension "media3"
+      minSdk 19 // minSdk is 19 before 1.4
     }
     at_1_4 {
       dimension "media3"
-      minSdk 21 // media3 has a minSdk of 21 since v1.4
     }
   }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -14,7 +14,6 @@ android {
 
   defaultConfig {
     minSdk 19
-    targetSdk 34
 
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles "consumer-rules.pro"
@@ -41,6 +40,7 @@ android {
     }
     at_1_4 {
       dimension "media3"
+      minSdk 21 // media3 has a minSdk of 21 since v1.4
     }
   }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
   namespace 'com.mux.stats.sdk.muxstats.media3'
-  compileSdk 34
+  compileSdk 35
 
   buildFeatures {
     buildConfig = true


### PR DESCRIPTION
This matches the new media3 v1.4 update, which moves it's minimum supported API to 21/Lollipop

This change also updates the `compileSdk` but that is not public-facing