### PR TITLE
Releases/v1.6.0

### DIFF
--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/Constants.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/Constants.kt
@@ -8,5 +8,6 @@ object Constants {
   const val VOD_TEST_URL_BIG_BUCK_BUNNY = "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8"
   const val AD_TAG_SIMPLE_W_MID_ROLL = "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/vmap_ad_samples&sz=640x480&cust_params=sample_ar%3Dpremidpostoptimizedpod&ciu_szs=300x250&gdfp_req=1&ad_rule=1&output=vmap&unviewed_position_start=1&env=vp&impl=s&cmsid=496&vid=short_onecue&correlator="
   const val AD_TAG_COMPLEX = "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/vmap_ad_samples&sz=640x480&cust_params=sample_ar%3Dpremidpostlongpod&ciu_szs=300x250&gdfp_req=1&ad_rule=1&output=vmap&unviewed_position_start=1&env=vp&impl=s&cmsid=496&vid=short_onecue&correlator="
+  const val AD_TAG_BROKEN_REDIRECT = "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_ad_samples&sz=640x480&cust_params=sample_ct%3Dredirecterror&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator="
   const val SSAI_ASSET_TAG_BUCK = "c-rArva4ShKVIAkNfy6HUQ"
 }

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaClientAdsActivity.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaClientAdsActivity.kt
@@ -99,7 +99,7 @@ class ImaClientAdsActivity : AppCompatActivity() {
     val customerData = CustomerData(
       CustomerPlayerData().apply { },
       CustomerVideoData().apply {
-        title = "Mux Data SDK for Media3 Demo"
+        videoTitle = "Mux Data for Media3 - CSAI Ads"
       },
       CustomerViewData().apply { }
     )

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaServerAdsActivity.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaServerAdsActivity.kt
@@ -161,7 +161,7 @@ class ImaServerAdsActivity : AppCompatActivity() {
     val customerData = CustomerData(
       CustomerPlayerData().apply { },
       CustomerVideoData().apply {
-        title = "Mux Data SDK for Media3 Demo"
+        videoTitle = "Mux Data SDK for Media3 Demo"
       },
       CustomerViewData().apply { }
     )

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaServerAdsActivity.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaServerAdsActivity.kt
@@ -161,7 +161,7 @@ class ImaServerAdsActivity : AppCompatActivity() {
     val customerData = CustomerData(
       CustomerPlayerData().apply { },
       CustomerVideoData().apply {
-        videoTitle = "Mux Data SDK for Media3 Demo"
+        videoTitle = "Mux Data SDK for Media3 - Server Ads"
       },
       CustomerViewData().apply { }
     )

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
 plugins {
-  id 'com.android.application' version '8.5.2' apply false
-  id 'com.android.library' version '8.5.2' apply false
+  id 'com.android.application' version '8.6.0' apply false
+  id 'com.android.library' version '8.6.0' apply false
   id 'org.jetbrains.kotlin.android' version '1.9.24' apply false
   id 'com.mux.gradle.android.mux-android-distribution' version '1.3.0' apply false
   id "org.jetbrains.dokka" version "1.6.10"
@@ -9,7 +9,7 @@ plugins {
 
 allprojects {
   project.ext {
-    coreVersion = '1.4.0'
+    coreVersion = '1.4.1'
   }
 
   tasks.withType(DokkaTaskPartial.class) {

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 allprojects {
   project.ext {
-    coreVersion = '1.4.1'
+    coreVersion = '1.4.2'
   }
 
   tasks.withType(DokkaTaskPartial.class) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Nov 18 08:57:39 PST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/ImaAdsLoaderExt.kt
+++ b/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/ImaAdsLoaderExt.kt
@@ -36,7 +36,7 @@ fun ImaAdsLoader.Builder.monitorWith(
 
   setAdEventListener(adsListener)
   setAdErrorListener(adsListener)
-  customerAdPlayerAdCallback?.let { setVideoAdPlayerCallback(adsListener) }
+  setVideoAdPlayerCallback(adsListener)
 
   return this
 }

--- a/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/ImaAdsLoaderExt.kt
+++ b/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/ImaAdsLoaderExt.kt
@@ -5,13 +5,15 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ima.ImaAdsLoader
 import com.google.ads.interactivemedia.v3.api.AdErrorEvent.AdErrorListener
 import com.google.ads.interactivemedia.v3.api.AdEvent.AdEventListener
+import com.google.ads.interactivemedia.v3.api.player.VideoAdPlayer.VideoAdPlayerCallback
 import com.mux.stats.sdk.muxstats.MuxStatsSdkMedia3
 
 /**
  * Monitors the [ImaAdsLoader] created by the given [ImaAdsLoader.Builder].
  *
- * Mux must take ownership of the [AdErrorListener] and [AdEventListener] for this ads loader, but
- * you can provide your own listeners and logic using the provided optional params
+ * Mux must take ownership of the [AdErrorListener], [AdEventListener], and [VideoAdPlayerCallback]
+ * for this ads loader, but you can provide your own listeners and logic using the provided optional
+ * params.
  *
  * @param muxStats The [MuxStatsSdkMedia3] instance monitoring your player
  * @param customerAdEventListener Optional. An [AdEventListener] with your apps custom ad-event handling
@@ -23,15 +25,18 @@ fun ImaAdsLoader.Builder.monitorWith(
   muxStats: MuxStatsSdkMedia3<*>,
   customerAdEventListener: AdEventListener = AdEventListener { },
   customerAdErrorListener: AdErrorListener = AdErrorListener { },
+  customerAdPlayerAdCallback: VideoAdPlayerCallback? = null
 ): ImaAdsLoader.Builder {
   val adsListener = MuxImaAdsListener.newListener(
-    { muxStats },
+    muxStats,
     customerAdEventListener,
-    customerAdErrorListener
+    customerAdErrorListener,
+    customerAdPlayerAdCallback,
   )
 
   setAdEventListener(adsListener)
   setAdErrorListener(adsListener)
+  customerAdPlayerAdCallback?.let { setVideoAdPlayerCallback(adsListener) }
 
   return this
 }

--- a/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/ServerSideImaAdsLoaderExt.kt
+++ b/library-ima/src/main/java/com/mux/stats/sdk/media3_ima/ServerSideImaAdsLoaderExt.kt
@@ -3,13 +3,18 @@ package com.mux.stats.sdk.media3_ima
 import androidx.annotation.OptIn
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ima.ImaAdsLoader
+import androidx.media3.exoplayer.ima.ImaServerSideAdInsertionMediaSource
 import androidx.media3.exoplayer.ima.ImaServerSideAdInsertionMediaSource.AdsLoader
 import com.google.ads.interactivemedia.v3.api.AdErrorEvent.AdErrorListener
 import com.google.ads.interactivemedia.v3.api.AdEvent.AdEventListener
 import com.mux.stats.sdk.muxstats.MuxStatsSdkMedia3
 
 /**
- * Monitors the [ImaAdsLoader] created by the given [ImaAdsLoader.Builder].
+ * Monitors the [ImaServerSideAdInsertionMediaSource.AdsLoader] created by the a
+ * [ImaServerSideAdInsertionMediaSource.AdsLoader.Builder].
+ *
+ * This method is just for DAI server-side ad-insertion. If you're doing Client-Side Ad Insertion
+ * (CSAI), use [ImaAdsLoader.Builder.monitorWith]
  *
  * Mux must take ownership of the [AdErrorListener] and [AdEventListener] for this ads loader, but
  * you can provide your own listeners and logic using the provided optional params

--- a/library/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsSdkMedia3.kt
+++ b/library/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsSdkMedia3.kt
@@ -11,6 +11,7 @@ import com.mux.stats.sdk.core.events.EventBus
 import com.mux.stats.sdk.core.events.playback.AdEvent
 import com.mux.stats.sdk.core.model.CustomerData
 import com.mux.stats.sdk.core.model.CustomerVideoData
+import com.mux.stats.sdk.core.util.MuxLogger
 import com.mux.stats.sdk.muxstats.media3.BuildConfig
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -61,6 +62,7 @@ class MuxStatsSdkMedia3<P : Player> @OptIn(UnstableApi::class) @JvmOverloads con
   ),
   makeNetworkRequest = { iDevice -> network ?: MuxNetwork(iDevice, CoroutineScope(Dispatchers.IO)) }
 ) {
+
   /**
    * Collects events related to ad playback and reports them. If you are using Google IMA, you don't
    * need to interact with this class directly. Instead, use the `media3-ima` library provided by


### PR DESCRIPTION
## Updates
* Better tracking of ad events. If you are using a `VideoPlayerAdCallback` supply it to `ImaAdsLoader.monitorWith` (#82).

## Fixes
* fix: rebuffering not ended when seeking starts
* fix: extra-verbose logging causing crashes in some cases

### Internal lib updates
* Update `stats.java` to 8.1.2
* Update `muxstats.android` to 1.4.2

Co-authored-by: Emily Dixon <edixon@mux.com>
Co-authored-by: Tomislav Kordic <32546640+tomkordic@users.noreply.github.com>
Co-authored-by: GitHub <noreply@github.com>

