### PR TITLE
fix: suppress some ad events when outside of an ad break

### DIFF
--- a/library/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsSdkMedia3.kt
+++ b/library/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsSdkMedia3.kt
@@ -6,7 +6,6 @@ import androidx.annotation.OptIn
 import androidx.media3.common.MediaLibraryInfo
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
-import com.mux.android.util.oneOf
 import com.mux.android.util.noneOf
 import com.mux.stats.sdk.core.CustomOptions
 import com.mux.stats.sdk.core.events.EventBus

--- a/library/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsSdkMedia3.kt
+++ b/library/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsSdkMedia3.kt
@@ -154,22 +154,23 @@ class AdCollector private constructor(
   }
 
   fun dispatch(event: AdEvent) {
-    if (muxPlayerState == MuxPlayerState.PLAYING_ADS) {
+
+    if (
+      muxPlayerState != MuxPlayerState.PLAYING_ADS &&
+      event.type.noneOf(
+        AdPlayingEvent.TYPE,
+        AdPlayEvent.TYPE,
+        AdFirstQuartileEvent.TYPE,
+        AdMidpointEvent.TYPE,
+        AdThirdQuartileEvent.TYPE,
+        AdEndedEvent.TYPE,
+        AdBreakEndEvent.TYPE,
+        AdPauseEvent.TYPE
+      )
+      ) {
       eventBus.dispatch(event)
-    } else {
-      if (
-        event.type.noneOf(
-          AdPlayingEvent.TYPE,
-          AdPlayEvent.TYPE,
-          AdFirstQuartileEvent.TYPE,
-          AdMidpointEvent.TYPE,
-          AdThirdQuartileEvent.TYPE,
-          AdEndedEvent.TYPE,
-          AdBreakEndEvent.TYPE,
-          AdPauseEvent.TYPE
-        )) {
-          eventBus.dispatch(event)
-      }
+    } else if (muxPlayerState == MuxPlayerState.PLAYING_ADS) {
+      eventBus.dispatch(event)
     }
   }
 

--- a/library/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsSdkMedia3.kt
+++ b/library/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsSdkMedia3.kt
@@ -159,7 +159,7 @@ class AdCollector private constructor(
       eventBus.dispatch(event)
     } else {
       if (
-        event.type.oneOf(
+        event.type.noneOf(
           AdPlayingEvent.TYPE,
           AdPlayEvent.TYPE,
           AdFirstQuartileEvent.TYPE,

--- a/library/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsSdkMedia3.kt
+++ b/library/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsSdkMedia3.kt
@@ -7,6 +7,7 @@ import androidx.media3.common.MediaLibraryInfo
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import com.mux.android.util.oneOf
+import com.mux.android.util.noneOf
 import com.mux.stats.sdk.core.CustomOptions
 import com.mux.stats.sdk.core.events.EventBus
 import com.mux.stats.sdk.core.events.playback.AdBreakEndEvent
@@ -158,7 +159,7 @@ class AdCollector private constructor(
       eventBus.dispatch(event)
     } else {
       if (
-        event.type.noneOf(
+        event.type.oneOf(
           AdPlayingEvent.TYPE,
           AdPlayEvent.TYPE,
           AdFirstQuartileEvent.TYPE,

--- a/library/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsSdkMedia3.kt
+++ b/library/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsSdkMedia3.kt
@@ -9,6 +9,7 @@ import androidx.media3.common.util.UnstableApi
 import com.mux.stats.sdk.core.CustomOptions
 import com.mux.stats.sdk.core.events.EventBus
 import com.mux.stats.sdk.core.events.playback.AdEvent
+import com.mux.stats.sdk.core.events.playback.AdPlayingEvent
 import com.mux.stats.sdk.core.model.CustomerData
 import com.mux.stats.sdk.core.model.CustomerVideoData
 import com.mux.stats.sdk.core.util.MuxLogger
@@ -145,7 +146,14 @@ class AdCollector private constructor(
   }
 
   fun dispatch(event: AdEvent) {
-    eventBus.dispatch(event)
+    if (muxPlayerState == MuxPlayerState.PLAYING_ADS) {
+      eventBus.dispatch(event)
+    } else {
+      // TODO: Filter other ad event types like `adplay`, etc here as well
+      if (event.type != AdPlayingEvent.TYPE) {
+        eventBus.dispatch(event)
+      }
+    }
   }
 
   companion object {

--- a/library/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsSdkMedia3.kt
+++ b/library/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsSdkMedia3.kt
@@ -6,10 +6,18 @@ import androidx.annotation.OptIn
 import androidx.media3.common.MediaLibraryInfo
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
+import com.mux.android.util.oneOf
 import com.mux.stats.sdk.core.CustomOptions
 import com.mux.stats.sdk.core.events.EventBus
+import com.mux.stats.sdk.core.events.playback.AdBreakEndEvent
+import com.mux.stats.sdk.core.events.playback.AdEndedEvent
 import com.mux.stats.sdk.core.events.playback.AdEvent
+import com.mux.stats.sdk.core.events.playback.AdFirstQuartileEvent
+import com.mux.stats.sdk.core.events.playback.AdMidpointEvent
+import com.mux.stats.sdk.core.events.playback.AdPauseEvent
+import com.mux.stats.sdk.core.events.playback.AdPlayEvent
 import com.mux.stats.sdk.core.events.playback.AdPlayingEvent
+import com.mux.stats.sdk.core.events.playback.AdThirdQuartileEvent
 import com.mux.stats.sdk.core.model.CustomerData
 import com.mux.stats.sdk.core.model.CustomerVideoData
 import com.mux.stats.sdk.core.util.MuxLogger
@@ -149,9 +157,18 @@ class AdCollector private constructor(
     if (muxPlayerState == MuxPlayerState.PLAYING_ADS) {
       eventBus.dispatch(event)
     } else {
-      // TODO: Filter other ad event types like `adplay`, etc here as well
-      if (event.type != AdPlayingEvent.TYPE) {
-        eventBus.dispatch(event)
+      if (
+        event.type.noneOf(
+          AdPlayingEvent.TYPE,
+          AdPlayEvent.TYPE,
+          AdFirstQuartileEvent.TYPE,
+          AdMidpointEvent.TYPE,
+          AdThirdQuartileEvent.TYPE,
+          AdEndedEvent.TYPE,
+          AdBreakEndEvent.TYPE,
+          AdPauseEvent.TYPE
+        )) {
+          eventBus.dispatch(event)
       }
     }
   }

--- a/library/src/test/java/com/mux/stats/sdk/muxstats/AdCollectorTests.kt
+++ b/library/src/test/java/com/mux/stats/sdk/muxstats/AdCollectorTests.kt
@@ -110,7 +110,7 @@ class AdCollectorTests : AbsRobolectricTest() {
 
     Assert.assertTrue(
       "aderror should be sent to event bus",
-      dispatchedEvents.find { it is AdErrorEvent } == null
+      dispatchedEvents.find { it is AdErrorEvent } != null
     )
 
     adCollector.onStartPlayingAds()

--- a/library/src/test/java/com/mux/stats/sdk/muxstats/AdCollectorTests.kt
+++ b/library/src/test/java/com/mux/stats/sdk/muxstats/AdCollectorTests.kt
@@ -78,7 +78,7 @@ class AdCollectorTests : AbsRobolectricTest() {
       dispatchedEvents.find { it is AdPlayingEvent } == null
     )
 
-    dispatchedEvents.removeAll()
+    dispatchedEvents.clear()
     adCollector.onStartPlayingAds()
 
     adCollector.dispatch(AdPlayEvent(null))
@@ -94,7 +94,7 @@ class AdCollectorTests : AbsRobolectricTest() {
       dispatchedEvents.find { it is AdPlayingEvent } != null
     )
 
-    dispatchedEvents.removeAll()
+    dispatchedEvents.clear()
     adCollector.onFinishPlayingAds(willPlay = true)
 
     adCollector.dispatch(AdPlayEvent(null))
@@ -131,7 +131,7 @@ class AdCollectorTests : AbsRobolectricTest() {
       dispatchedEvents.find { it is AdErrorEvent } != null
     )
 
-    dispatchedEvents.removeAll()
+    dispatchedEvents.clear()
     adCollector.onStartPlayingAds()
 
     adCollector.dispatch(AdErrorEvent(null))
@@ -140,7 +140,7 @@ class AdCollectorTests : AbsRobolectricTest() {
       dispatchedEvents.find { it is AdErrorEvent } != null
     )
 
-    dispatchedEvents.removeAll()
+    dispatchedEvents.clear()
     adCollector.onFinishPlayingAds(willPlay = true)
 
     adCollector.dispatch(AdErrorEvent(null))
@@ -170,7 +170,7 @@ class AdCollectorTests : AbsRobolectricTest() {
       dispatchedEvents.find { it is AdRequestEvent } != null
     )
 
-    dispatchedEvents.removeAll()
+    dispatchedEvents.clear()
     adCollector.onStartPlayingAds()
 
     adCollector.dispatch(AdRequestEvent(null))
@@ -179,7 +179,7 @@ class AdCollectorTests : AbsRobolectricTest() {
       dispatchedEvents.find { it is AdRequestEvent } != null
     )
 
-    dispatchedEvents.removeAll()
+    dispatchedEvents.clear()
     adCollector.onFinishPlayingAds(willPlay = true)
 
     adCollector.dispatch(AdRequestEvent(null))
@@ -209,7 +209,7 @@ class AdCollectorTests : AbsRobolectricTest() {
       dispatchedEvents.find { it is AdResponseEvent } != null
     )
 
-    dispatchedEvents.removeAll()
+    dispatchedEvents.clear()
     adCollector.onStartPlayingAds()
 
     adCollector.dispatch(AdResponseEvent(null))
@@ -218,7 +218,7 @@ class AdCollectorTests : AbsRobolectricTest() {
       dispatchedEvents.find { it is AdResponseEvent } != null
     )
 
-    dispatchedEvents.removeAll()
+    dispatchedEvents.clear()
     adCollector.onFinishPlayingAds(willPlay = true)
 
     adCollector.dispatch(AdResponseEvent(null))

--- a/library/src/test/java/com/mux/stats/sdk/muxstats/AdCollectorTests.kt
+++ b/library/src/test/java/com/mux/stats/sdk/muxstats/AdCollectorTests.kt
@@ -76,6 +76,7 @@ class AdCollectorTests : AbsRobolectricTest() {
       dispatchedEvents.find { it is AdPlayingEvent } == null
     )
 
+    dispatchedEvents.removeAll()
     adCollector.onStartPlayingAds()
 
     adCollector.dispatch(AdPlayEvent(null))
@@ -89,6 +90,22 @@ class AdCollectorTests : AbsRobolectricTest() {
     Assert.assertTrue(
       "adplaying should not be sent to event bus",
       dispatchedEvents.find { it is AdPlayingEvent } != null
+    )
+
+    dispatchedEvents.removeAll()
+    adCollector.onFinishPlayingAds(willPlay = true)
+
+    adCollector.dispatch(AdPlayEvent(null))
+    adCollector.dispatch(AdPlayingEvent(null))
+
+    Assert.assertTrue(
+      "adplay should not be sent to event bus",
+      dispatchedEvents.find { it is AdPlayEvent } == null
+    )
+
+    Assert.assertTrue(
+      "adplaying should not be sent to event bus",
+      dispatchedEvents.find { it is AdPlayingEvent } == null
     )
   }
 
@@ -107,12 +124,12 @@ class AdCollectorTests : AbsRobolectricTest() {
     val adCollector = AdCollector.create(stateCollector, eventBus)
 
     adCollector.dispatch(AdErrorEvent(null))
-
     Assert.assertTrue(
       "aderror should be sent to event bus",
       dispatchedEvents.find { it is AdErrorEvent } != null
     )
 
+    dispatchedEvents.removeAll()
     adCollector.onStartPlayingAds()
 
     adCollector.dispatch(AdErrorEvent(null))
@@ -121,6 +138,7 @@ class AdCollectorTests : AbsRobolectricTest() {
       dispatchedEvents.find { it is AdErrorEvent } != null
     )
 
+    dispatchedEvents.removeAll()
     adCollector.onFinishPlayingAds(willPlay = true)
 
     adCollector.dispatch(AdErrorEvent(null))


### PR DESCRIPTION
Filter out events we do not expect to receive outside of an ad break.