### PR TITLE
fix: dropped frames not tracked + Update muxstats-android to v1.4.4 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 allprojects {
   project.ext {
-    coreVersion = '1.4.2'
+    coreVersion = '1.4.4'
   }
 
   tasks.withType(DokkaTaskPartial.class) {


### PR DESCRIPTION
Inherited from the android core SDK