### PR TITLE
Releases/v1.6.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -171,13 +171,13 @@ dependencies {
   At_latestImplementation "androidx.media3:media3-exoplayer-hls:1.4.1"
   At_latestImplementation "androidx.media3:media3-exoplayer-rtsp:1.4.1"
 
-  implementation 'androidx.core:core-ktx:1.12.0'
-  implementation 'androidx.appcompat:appcompat:1.6.1'
-  implementation 'com.google.android.material:material:1.10.0'
-  implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+  implementation 'androidx.core:core-ktx:1.15.0'
+  implementation 'androidx.appcompat:appcompat:1.7.0'
+  implementation 'com.google.android.material:material:1.12.0'
+  implementation 'androidx.constraintlayout:constraintlayout:2.2.0'
   testImplementation 'junit:junit:4.13.2'
-  androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-  androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+  androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+  androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
   debugImplementation 'androidx.compose.ui:ui-tooling'
   debugImplementation 'androidx.compose.ui:ui-test-manifest'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 allprojects {
   project.ext {
-    coreVersion = '1.4.2'
+    coreVersion = '1.4.4'
   }
 
   tasks.withType(DokkaTaskPartial.class) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,5 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -144,8 +144,8 @@ dependencies {
   At_latestCompileOnly "androidx.media3:media3-exoplayer-hls:1.4.0"
 
   testImplementation 'junit:junit:4.13.2'
-  androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-  androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+  androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+  androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }
 
 afterEvaluate {

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -132,18 +132,20 @@ dependencies {
   at_1_4Api "androidx.media3:media3-exoplayer-ima:1.4.0"
   //noinspection GradleDependency
   at_1_4Api "androidx.media3:media3-exoplayer:1.4.0"
+  //noinspection GradleDependency
   At_latestApi "androidx.media3:media3-exoplayer-ima:1.4.0"
+  //noinspection GradleDependency
   At_latestApi "androidx.media3:media3-exoplayer:1.4.0"
 
-  implementation 'androidx.core:core-ktx:1.13.1'
+  implementation 'androidx.core:core-ktx:1.15.0'
 
   testImplementation 'junit:junit:4.13.2'
-  testImplementation 'androidx.test.ext:junit:1.1.5'
+  testImplementation 'androidx.test.ext:junit:1.2.1'
   testImplementation "io.mockk:mockk:1.12.3"
-  testImplementation 'org.robolectric:robolectric:4.10.3'
+  testImplementation 'org.robolectric:robolectric:4.11.1'
 
-  androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-  androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+  androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+  androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }
 
 afterEvaluate {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -120,16 +120,18 @@ dependencies {
   at_1_2Api "androidx.media3:media3-common:1.2.0"
   //noinspection GradleDependency
   at_1_3Api "androidx.media3:media3-common:1.3.0"
+  //noinspection GradleDependency // benefit from optimistic matching
   at_1_4Api "androidx.media3:media3-common:1.4.0"
+  //noinspection GradleDependency // benefit from optimistic matching
   At_latestApi "androidx.media3:media3-common:1.4.0"
 
-  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1"
 
   testImplementation 'junit:junit:4.13.2'
-  testImplementation 'androidx.test.ext:junit:1.1.5'
+  testImplementation 'androidx.test.ext:junit:1.2.1'
   testImplementation "io.mockk:mockk:1.12.3"
-  testImplementation 'org.robolectric:robolectric:4.10.3'
+  testImplementation 'org.robolectric:robolectric:4.11.1'
 
-  androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-  androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+  androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+  androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }

--- a/library/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsSdkMedia3.kt
+++ b/library/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsSdkMedia3.kt
@@ -6,9 +6,18 @@ import androidx.annotation.OptIn
 import androidx.media3.common.MediaLibraryInfo
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
+import com.mux.android.util.noneOf
 import com.mux.stats.sdk.core.CustomOptions
 import com.mux.stats.sdk.core.events.EventBus
+import com.mux.stats.sdk.core.events.playback.AdBreakEndEvent
+import com.mux.stats.sdk.core.events.playback.AdEndedEvent
 import com.mux.stats.sdk.core.events.playback.AdEvent
+import com.mux.stats.sdk.core.events.playback.AdFirstQuartileEvent
+import com.mux.stats.sdk.core.events.playback.AdMidpointEvent
+import com.mux.stats.sdk.core.events.playback.AdPauseEvent
+import com.mux.stats.sdk.core.events.playback.AdPlayEvent
+import com.mux.stats.sdk.core.events.playback.AdPlayingEvent
+import com.mux.stats.sdk.core.events.playback.AdThirdQuartileEvent
 import com.mux.stats.sdk.core.model.CustomerData
 import com.mux.stats.sdk.core.model.CustomerVideoData
 import com.mux.stats.sdk.core.util.MuxLogger
@@ -145,7 +154,24 @@ class AdCollector private constructor(
   }
 
   fun dispatch(event: AdEvent) {
-    eventBus.dispatch(event)
+
+    if (
+      muxPlayerState != MuxPlayerState.PLAYING_ADS &&
+      event.type.noneOf(
+        AdPlayingEvent.TYPE,
+        AdPlayEvent.TYPE,
+        AdFirstQuartileEvent.TYPE,
+        AdMidpointEvent.TYPE,
+        AdThirdQuartileEvent.TYPE,
+        AdEndedEvent.TYPE,
+        AdBreakEndEvent.TYPE,
+        AdPauseEvent.TYPE
+      )
+      ) {
+      eventBus.dispatch(event)
+    } else if (muxPlayerState == MuxPlayerState.PLAYING_ADS) {
+      eventBus.dispatch(event)
+    }
   }
 
   companion object {

--- a/library/src/test/java/com/mux/stats/sdk/muxstats/AdCollectorTests.kt
+++ b/library/src/test/java/com/mux/stats/sdk/muxstats/AdCollectorTests.kt
@@ -3,6 +3,11 @@ package com.mux.stats.sdk.muxstats
 import com.mux.stats.media3.test.tools.AbsRobolectricTest
 import com.mux.stats.sdk.core.events.EventBus
 import com.mux.stats.sdk.core.events.IEvent
+import com.mux.stats.sdk.core.events.playback.AdErrorEvent
+import com.mux.stats.sdk.core.events.playback.AdPlayEvent
+import com.mux.stats.sdk.core.events.playback.AdPlayingEvent
+import com.mux.stats.sdk.core.events.playback.AdRequestEvent
+import com.mux.stats.sdk.core.events.playback.AdResponseEvent
 import com.mux.stats.sdk.core.events.playback.RebufferEndEvent
 import io.mockk.every
 import io.mockk.just
@@ -44,5 +49,182 @@ class AdCollectorTests : AbsRobolectricTest() {
       dispatchedEvents.find { it is RebufferEndEvent } != null
     )
 
+  }
+
+  @Test
+  fun testDispatchesAdPlayAndAdPlayingOnlyDuringAdBreaks() {
+    val dispatchedEvents = mutableListOf<IEvent>()
+    val eventBus = mockk<EventBus> {
+      every { addListener(any()) } just runs
+      every { removeListener(any()) } just runs
+      every { removeAllListeners() } just runs
+      every { dispatch(any()) } answers { call ->
+        dispatchedEvents += (call.invocation.args.first() as IEvent)
+      }
+    }
+    val stateCollector = MuxStateCollector(mockk<MuxStats>(relaxed = true), eventBus)
+    val adCollector = AdCollector.create(stateCollector, eventBus)
+
+    adCollector.dispatch(AdPlayEvent(null))
+    adCollector.dispatch(AdPlayingEvent(null))
+
+    Assert.assertTrue(
+      "adplay should not be sent to event bus",
+      dispatchedEvents.find { it is AdPlayEvent } == null
+    )
+
+    Assert.assertTrue(
+      "adplaying should not be sent to event bus",
+      dispatchedEvents.find { it is AdPlayingEvent } == null
+    )
+
+    dispatchedEvents.clear()
+    adCollector.onStartPlayingAds()
+
+    adCollector.dispatch(AdPlayEvent(null))
+    adCollector.dispatch(AdPlayingEvent(null))
+
+    Assert.assertTrue(
+      "adplay should not be sent to event bus",
+      dispatchedEvents.find { it is AdPlayEvent } != null
+    )
+
+    Assert.assertTrue(
+      "adplaying should not be sent to event bus",
+      dispatchedEvents.find { it is AdPlayingEvent } != null
+    )
+
+    dispatchedEvents.clear()
+    adCollector.onFinishPlayingAds(willPlay = true)
+
+    adCollector.dispatch(AdPlayEvent(null))
+    adCollector.dispatch(AdPlayingEvent(null))
+
+    Assert.assertTrue(
+      "adplay should not be sent to event bus",
+      dispatchedEvents.find { it is AdPlayEvent } == null
+    )
+
+    Assert.assertTrue(
+      "adplaying should not be sent to event bus",
+      dispatchedEvents.find { it is AdPlayingEvent } == null
+    )
+  }
+
+  @Test
+  fun testDispatchesAdErrorBothDuringAndOutsideOfAdBreaks() {
+    val dispatchedEvents = mutableListOf<IEvent>()
+    val eventBus = mockk<EventBus> {
+      every { addListener(any()) } just runs
+      every { removeListener(any()) } just runs
+      every { removeAllListeners() } just runs
+      every { dispatch(any()) } answers { call ->
+        dispatchedEvents += (call.invocation.args.first() as IEvent)
+      }
+    }
+    val stateCollector = MuxStateCollector(mockk<MuxStats>(relaxed = true), eventBus)
+    val adCollector = AdCollector.create(stateCollector, eventBus)
+
+    adCollector.dispatch(AdErrorEvent(null))
+    Assert.assertTrue(
+      "aderror should be sent to event bus before the start of an ad break",
+      dispatchedEvents.find { it is AdErrorEvent } != null
+    )
+
+    dispatchedEvents.clear()
+    adCollector.onStartPlayingAds()
+
+    adCollector.dispatch(AdErrorEvent(null))
+    Assert.assertTrue(
+      "aderror should be sent to event bus during an ad break",
+      dispatchedEvents.find { it is AdErrorEvent } != null
+    )
+
+    dispatchedEvents.clear()
+    adCollector.onFinishPlayingAds(willPlay = true)
+
+    adCollector.dispatch(AdErrorEvent(null))
+    Assert.assertTrue(
+      "aderror should be sent to event bus after an ad break is finished",
+      dispatchedEvents.find { it is AdErrorEvent } != null
+    )
+  }
+
+  @Test
+  fun testDispatchesAdRequestBothDuringAndOutsideOfAdBreaks() {
+    val dispatchedEvents = mutableListOf<IEvent>()
+    val eventBus = mockk<EventBus> {
+      every { addListener(any()) } just runs
+      every { removeListener(any()) } just runs
+      every { removeAllListeners() } just runs
+      every { dispatch(any()) } answers { call ->
+        dispatchedEvents += (call.invocation.args.first() as IEvent)
+      }
+    }
+    val stateCollector = MuxStateCollector(mockk<MuxStats>(relaxed = true), eventBus)
+    val adCollector = AdCollector.create(stateCollector, eventBus)
+
+    adCollector.dispatch(AdRequestEvent(null))
+    Assert.assertTrue(
+      "adrequest should be sent to event bus before the start of an ad break",
+      dispatchedEvents.find { it is AdRequestEvent } != null
+    )
+
+    dispatchedEvents.clear()
+    adCollector.onStartPlayingAds()
+
+    adCollector.dispatch(AdRequestEvent(null))
+    Assert.assertTrue(
+      "adrequest should be sent to event bus during an ad break",
+      dispatchedEvents.find { it is AdRequestEvent } != null
+    )
+
+    dispatchedEvents.clear()
+    adCollector.onFinishPlayingAds(willPlay = true)
+
+    adCollector.dispatch(AdRequestEvent(null))
+    Assert.assertTrue(
+      "adrequest should be sent to event bus  after an ad break is finished",
+      dispatchedEvents.find { it is AdRequestEvent } != null
+    )
+  }
+
+  @Test
+  fun testDispatchesAdResponseBothDuringAndOutsideOfAdBreaks() {
+    val dispatchedEvents = mutableListOf<IEvent>()
+    val eventBus = mockk<EventBus> {
+      every { addListener(any()) } just runs
+      every { removeListener(any()) } just runs
+      every { removeAllListeners() } just runs
+      every { dispatch(any()) } answers { call ->
+        dispatchedEvents += (call.invocation.args.first() as IEvent)
+      }
+    }
+    val stateCollector = MuxStateCollector(mockk<MuxStats>(relaxed = true), eventBus)
+    val adCollector = AdCollector.create(stateCollector, eventBus)
+
+    adCollector.dispatch(AdResponseEvent(null))
+    Assert.assertTrue(
+      "adresponse should be sent to event bus before the start of an ad break",
+      dispatchedEvents.find { it is AdResponseEvent } != null
+    )
+
+    dispatchedEvents.clear()
+    adCollector.onStartPlayingAds()
+
+    adCollector.dispatch(AdResponseEvent(null))
+    Assert.assertTrue(
+      "adresponse should be sent to event bus during an ad break",
+      dispatchedEvents.find { it is AdResponseEvent } != null
+    )
+
+    dispatchedEvents.clear()
+    adCollector.onFinishPlayingAds(willPlay = true)
+
+    adCollector.dispatch(AdResponseEvent(null))
+    Assert.assertTrue(
+      "adresponse should be sent to event bus after an ad break is finished",
+      dispatchedEvents.find { it is AdResponseEvent } != null
+    )
   }
 }


### PR DESCRIPTION
## Improvements

* fix: suppress some ad events when outside of an ad break (#102)
* fix: dropped frames not tracked (#103)

### Internal Library Updates
* Update `muxstats-android` to v1.4.4


Co-authored-by: AJ Lauer Barinov <abarinov@mux.com>
Co-authored-by: Emily Dixon <edixon@mux.com>
Co-authored-by: GitHub <noreply@github.com>