### PR TITLE
Releases/v1.6.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,6 +31,7 @@ android {
     at_1_2 { dimension "media3" }
     at_1_3 { dimension "media3" }
     at_1_4 { dimension "media3" }
+    at_1_5 { dimension "media3" }
   }
 
   sourceSets {
@@ -50,6 +51,9 @@ android {
       java.srcDirs += "src/compatFrom1_3/java"
     }
     at_1_4 {
+      java.srcDirs += "src/compatFrom1_3/java"
+    }
+    at_1_5 {
       java.srcDirs += "src/compatFrom1_3/java"
     }
   }
@@ -155,13 +159,35 @@ dependencies {
   //noinspection GradleDependency
   at_1_3Implementation "androidx.media3:media3-exoplayer-rtsp:1.3.0"
 
+  //noinspection GradleDependency
   at_1_4Implementation "androidx.media3:media3-exoplayer:1.4.1"
+  //noinspection GradleDependency
   at_1_4Implementation "androidx.media3:media3-session:1.4.1"
+  //noinspection GradleDependency
   at_1_4Implementation "androidx.media3:media3-ui:1.4.1"
+  //noinspection GradleDependency
   at_1_4Implementation "androidx.media3:media3-exoplayer-ima:1.4.1"
+  //noinspection GradleDependency
   at_1_4Implementation "androidx.media3:media3-exoplayer-dash:1.4.1"
+  //noinspection GradleDependency
   at_1_4Implementation "androidx.media3:media3-exoplayer-hls:1.4.1"
+  //noinspection GradleDependency
   at_1_4Implementation "androidx.media3:media3-exoplayer-rtsp:1.4.1"
+
+  //noinspection GradleDependency
+  at_1_5Implementation "androidx.media3:media3-exoplayer:1.5.1"
+  //noinspection GradleDependency
+  at_1_5Implementation "androidx.media3:media3-session:1.5.1"
+  //noinspection GradleDependency
+  at_1_5Implementation "androidx.media3:media3-ui:1.5.1"
+  //noinspection GradleDependency
+  at_1_5Implementation "androidx.media3:media3-exoplayer-ima:1.5.1"
+  //noinspection GradleDependency
+  at_1_5Implementation "androidx.media3:media3-exoplayer-dash:1.5.1"
+  //noinspection GradleDependency
+  at_1_5Implementation "androidx.media3:media3-exoplayer-hls:1.5.1"
+  //noinspection GradleDependency
+  at_1_5Implementation "androidx.media3:media3-exoplayer-rtsp:1.5.1"
 
   At_latestImplementation "androidx.media3:media3-exoplayer:1.4.1"
   At_latestImplementation "androidx.media3:media3-session:1.4.1"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -175,27 +175,27 @@ dependencies {
   at_1_4Implementation "androidx.media3:media3-exoplayer-rtsp:1.4.1"
 
   //noinspection GradleDependency
-  at_1_5Implementation "androidx.media3:media3-exoplayer:1.5.1"
+  at_1_5Implementation "androidx.media3:media3-exoplayer:1.5.0"
   //noinspection GradleDependency
-  at_1_5Implementation "androidx.media3:media3-session:1.5.1"
+  at_1_5Implementation "androidx.media3:media3-session:1.5.0"
   //noinspection GradleDependency
-  at_1_5Implementation "androidx.media3:media3-ui:1.5.1"
+  at_1_5Implementation "androidx.media3:media3-ui:1.5.0"
   //noinspection GradleDependency
-  at_1_5Implementation "androidx.media3:media3-exoplayer-ima:1.5.1"
+  at_1_5Implementation "androidx.media3:media3-exoplayer-ima:1.5.0"
   //noinspection GradleDependency
-  at_1_5Implementation "androidx.media3:media3-exoplayer-dash:1.5.1"
+  at_1_5Implementation "androidx.media3:media3-exoplayer-dash:1.5.0"
   //noinspection GradleDependency
-  at_1_5Implementation "androidx.media3:media3-exoplayer-hls:1.5.1"
+  at_1_5Implementation "androidx.media3:media3-exoplayer-hls:1.5.0"
   //noinspection GradleDependency
-  at_1_5Implementation "androidx.media3:media3-exoplayer-rtsp:1.5.1"
+  at_1_5Implementation "androidx.media3:media3-exoplayer-rtsp:1.5.0"
 
-  At_latestImplementation "androidx.media3:media3-exoplayer:1.4.1"
-  At_latestImplementation "androidx.media3:media3-session:1.4.1"
-  At_latestImplementation "androidx.media3:media3-ui:1.4.1"
-  At_latestImplementation "androidx.media3:media3-exoplayer-ima:1.4.1"
-  At_latestImplementation "androidx.media3:media3-exoplayer-dash:1.4.1"
-  At_latestImplementation "androidx.media3:media3-exoplayer-hls:1.4.1"
-  At_latestImplementation "androidx.media3:media3-exoplayer-rtsp:1.4.1"
+  At_latestImplementation "androidx.media3:media3-exoplayer:1.5.0"
+  At_latestImplementation "androidx.media3:media3-session:1.5.0"
+  At_latestImplementation "androidx.media3:media3-ui:1.5.0"
+  At_latestImplementation "androidx.media3:media3-exoplayer-ima:1.5.0"
+  At_latestImplementation "androidx.media3:media3-exoplayer-dash:1.5.0"
+  At_latestImplementation "androidx.media3:media3-exoplayer-hls:1.5.0"
+  At_latestImplementation "androidx.media3:media3-exoplayer-rtsp:1.5.0"
 
   implementation 'androidx.core:core-ktx:1.15.0'
   implementation 'androidx.appcompat:appcompat:1.7.0'

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaClientAdsActivity.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/ima/ImaClientAdsActivity.kt
@@ -25,6 +25,7 @@ import com.mux.stats.sdk.core.model.CustomerPlayerData
 import com.mux.stats.sdk.core.model.CustomerVideoData
 import com.mux.stats.sdk.core.model.CustomerViewData
 import com.mux.stats.sdk.media3_ima.monitorWith
+import com.mux.stats.sdk.muxstats.MuxDataSdk
 import com.mux.stats.sdk.muxstats.MuxStatsSdkMedia3
 import com.mux.stats.sdk.muxstats.monitorWithMuxData
 
@@ -108,7 +109,7 @@ class ImaClientAdsActivity : AppCompatActivity() {
     return CustomerData(
       CustomerPlayerData().apply { },
       CustomerVideoData().apply {
-        videoTitle = "Media3 - IMA Ads: $title"
+        videoTitle = "Media3 - IMA: $title"
       },
       CustomerViewData().apply { },
       CustomData().apply {
@@ -174,6 +175,7 @@ class ImaClientAdsActivity : AppCompatActivity() {
 
     return player.monitorWithMuxData(
       context = this,
+      logLevel = MuxDataSdk.LogcatLevel.DEBUG,
       envKey = paramHelper.envKeyOrDefault(),
       customerData = customerData,
       playerView = view.playerView

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,8 @@ plugins {
 
 allprojects {
   project.ext {
-    coreVersion = '1.4.4'
+    coreVersion = 'dev-feat-defer-renditionchange-during-events-3f7da77'
+
   }
 
   tasks.withType(DokkaTaskPartial.class) {

--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,7 @@ plugins {
 
 allprojects {
   project.ext {
-    coreVersion = 'dev-feat-defer-renditionchange-during-events-3f7da77'
-
+    coreVersion = '1.4.5'
   }
 
   tasks.withType(DokkaTaskPartial.class) {

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -46,6 +46,9 @@ android {
     at_1_4 {
       dimension "media3"
     }
+    at_1_5 {
+      dimension "media3"
+    }
   }
 
   buildTypes {
@@ -139,9 +142,14 @@ dependencies {
   at_1_4CompileOnly "androidx.media3:media3-exoplayer-hls:1.4.0"
 
   //noinspection GradleDependency
-  At_latestApi "androidx.media3:media3-exoplayer:1.4.0"
+  at_1_5Api "androidx.media3:media3-exoplayer:1.5.0"
   //noinspection GradleDependency
-  At_latestCompileOnly "androidx.media3:media3-exoplayer-hls:1.4.0"
+  at_1_5CompileOnly "androidx.media3:media3-exoplayer-hls:1.5.0"
+
+  //noinspection GradleDependency
+  At_latestApi "androidx.media3:media3-exoplayer:1.5.0"
+  //noinspection GradleDependency
+  At_latestCompileOnly "androidx.media3:media3-exoplayer-hls:1.5.0"
 
   testImplementation 'junit:junit:4.13.2'
   androidTestImplementation 'androidx.test.ext:junit:1.2.1'

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/internal/ExoPlayerUtils.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/internal/ExoPlayerUtils.kt
@@ -1,0 +1,17 @@
+package com.mux.stats.sdk.muxstats.internal
+
+import androidx.annotation.OptIn
+import androidx.media3.common.C
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.source.MediaSource
+
+/**
+ * Returns true if the [MediaSource.MediaPeriodId] indicates that the period is in an ad break.
+ *
+ * Note the the default IMA and Media3 implementation report changing back to the main content
+ * format before the ad break is over.
+ */
+@OptIn(UnstableApi::class)
+fun MediaSource.MediaPeriodId.isInAdGroup(): Boolean {
+  return this.adGroupIndex != C.INDEX_UNSET || this.adIndexInAdGroup != C.INDEX_UNSET
+}

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -46,6 +46,9 @@ android {
     at_1_4 {
       dimension "media3"
     }
+    at_1_5 {
+      dimension "media3"
+    }
   }
 
   buildTypes {
@@ -133,9 +136,13 @@ dependencies {
   //noinspection GradleDependency
   at_1_4Api "androidx.media3:media3-exoplayer:1.4.0"
   //noinspection GradleDependency
-  At_latestApi "androidx.media3:media3-exoplayer-ima:1.4.0"
+  at_1_5Api "androidx.media3:media3-exoplayer-ima:1.5.0"
   //noinspection GradleDependency
-  At_latestApi "androidx.media3:media3-exoplayer:1.4.0"
+  at_1_5Api "androidx.media3:media3-exoplayer:1.5.0"
+  //noinspection GradleDependency
+  At_latestApi "androidx.media3:media3-exoplayer-ima:1.5.0"
+  //noinspection GradleDependency
+  At_latestApi "androidx.media3:media3-exoplayer:1.5.0"
 
   implementation 'androidx.core:core-ktx:1.15.0'
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -45,6 +45,9 @@ android {
     at_1_4 {
       dimension "media3"
     }
+    at_1_5 {
+      dimension "media3"
+    }
   }
 
   buildTypes {
@@ -123,7 +126,9 @@ dependencies {
   //noinspection GradleDependency // benefit from optimistic matching
   at_1_4Api "androidx.media3:media3-common:1.4.0"
   //noinspection GradleDependency // benefit from optimistic matching
-  At_latestApi "androidx.media3:media3-common:1.4.0"
+  at_1_5Api "androidx.media3:media3-common:1.5.0"
+  //noinspection GradleDependency // benefit from optimistic matching
+  At_latestApi "androidx.media3:media3-common:1.5.0"
 
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1"
 

--- a/library/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsSdkMedia3.kt
+++ b/library/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsSdkMedia3.kt
@@ -1,6 +1,7 @@
 package com.mux.stats.sdk.muxstats
 
 import android.content.Context
+import android.util.Log
 import android.view.View
 import androidx.annotation.OptIn
 import androidx.media3.common.MediaLibraryInfo
@@ -10,6 +11,7 @@ import com.mux.android.util.noneOf
 import com.mux.stats.sdk.core.CustomOptions
 import com.mux.stats.sdk.core.events.EventBus
 import com.mux.stats.sdk.core.events.playback.AdBreakEndEvent
+import com.mux.stats.sdk.core.events.playback.AdBreakStartEvent
 import com.mux.stats.sdk.core.events.playback.AdEndedEvent
 import com.mux.stats.sdk.core.events.playback.AdEvent
 import com.mux.stats.sdk.core.events.playback.AdFirstQuartileEvent
@@ -154,7 +156,6 @@ class AdCollector private constructor(
   }
 
   fun dispatch(event: AdEvent) {
-
     if (
       muxPlayerState != MuxPlayerState.PLAYING_ADS &&
       event.type.noneOf(


### PR DESCRIPTION
## Improvements
* update: add support for media3 1.5.x (#107)
* fix: content `renditionchange`s during ad breaks must be deferred until after the ad break (#106)

### Internal lib updates
* update `android` to v1.4.5
* update `muxstats.core` to v8.4.1



Co-authored-by: Emily Dixon <edixon@mux.com>
Co-authored-by: GitHub <noreply@github.com>