### PR TITLE
Releases/v1.7.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,8 @@ plugins {
 
 allprojects {
   project.ext {
-    coreVersion = '1.4.9'
+    androidCoreVersion = '1.4.9'
+    javaCoreVersion = '8.4.1'
   }
 
   tasks.withType(DokkaTaskPartial.class) {

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 allprojects {
   project.ext {
-    androidCoreVersion = '1.4.9'
+    androidCoreVersion = '1.4.10'
     javaCoreVersion = '8.4.1'
   }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -116,7 +116,8 @@ muxDistribution {
 }
 
 dependencies {
-  api "com.mux.stats.sdk.muxstats:android:${coreVersion}"
+  api "com.mux.stats.sdk.muxstats:android:${androidCoreVersion}"
+  api "com.mux:stats.muxcore:${javaCoreVersion}"
 
   //noinspection GradleDependency
   at_1_0Api "androidx.media3:media3-common:1.0.0"


### PR DESCRIPTION
## Improvements

* fix: viewerClientApplicationName and viewerClientApplicationVersion not reported

### Internal lib updates
* Update sdk.android to v1.4.10
* Update muxstats.java to v8.4.1
* This update also makes `sdk:android` and `muxstats.java` peers of each other. Previously, `sdk.android` depended on `muxstats.java`. This should be an internal-only change, but it's noted here in case you are tracking transitive dependencies in your build workflows



Co-authored-by: Emily Dixon <edixon@mux.com>