### PR TITLE
Releases/v1.8.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 android {
   namespace 'com.mux.stats.muxdatasdkformedia3'
-  compileSdk 35
+  compileSdk 36
 
   defaultConfig {
     applicationId "com.example.muxdatasdkformedia3"
@@ -33,6 +33,7 @@ android {
     at_1_4 { dimension "media3" }
     at_1_5 { dimension "media3" }
     at_1_6 { dimension "media3" }
+    at_1_8 { dimension "media3" }
   }
 
   sourceSets {
@@ -58,6 +59,9 @@ android {
       java.srcDirs += "src/compatFrom1_3/java"
     }
     at_1_6 {
+      java.srcDirs += "src/compatFrom1_3/java"
+    }
+    at_1_8 {
       java.srcDirs += "src/compatFrom1_3/java"
     }
   }
@@ -208,13 +212,28 @@ dependencies {
   //noinspection GradleDependency
   at_1_6Implementation "androidx.media3:media3-exoplayer-rtsp:1.6.0"
 
-  At_latestImplementation "androidx.media3:media3-exoplayer:1.6.0"
-  At_latestImplementation "androidx.media3:media3-session:1.6.0"
-  At_latestImplementation "androidx.media3:media3-ui:1.6.0"
-  At_latestImplementation "androidx.media3:media3-exoplayer-ima:1.6.0"
-  At_latestImplementation "androidx.media3:media3-exoplayer-dash:1.6.0"
-  At_latestImplementation "androidx.media3:media3-exoplayer-hls:1.6.0"
-  At_latestImplementation "androidx.media3:media3-exoplayer-rtsp:1.6.0"
+  //noinspection GradleDependency
+  at_1_8Implementation "androidx.media3:media3-exoplayer:1.8.0"
+  //noinspection GradleDependency
+  at_1_8Implementation "androidx.media3:media3-session:1.8.0"
+  //noinspection GradleDependency
+  at_1_8Implementation "androidx.media3:media3-ui:1.8.0"
+  //noinspection GradleDependency
+  at_1_8Implementation "androidx.media3:media3-exoplayer-ima:1.8.0"
+  //noinspection GradleDependency
+  at_1_8Implementation "androidx.media3:media3-exoplayer-dash:1.8.0"
+  //noinspection GradleDependency
+  at_1_8Implementation "androidx.media3:media3-exoplayer-hls:1.8.0"
+  //noinspection GradleDependency
+  at_1_8Implementation "androidx.media3:media3-exoplayer-rtsp:1.8.0"
+
+  At_latestImplementation "androidx.media3:media3-exoplayer:1.8.0"
+  At_latestImplementation "androidx.media3:media3-session:1.8.0"
+  At_latestImplementation "androidx.media3:media3-ui:1.8.0"
+  At_latestImplementation "androidx.media3:media3-exoplayer-ima:1.8.0"
+  At_latestImplementation "androidx.media3:media3-exoplayer-dash:1.8.0"
+  At_latestImplementation "androidx.media3:media3-exoplayer-hls:1.8.0"
+  At_latestImplementation "androidx.media3:media3-exoplayer-rtsp:1.8.0"
 
   implementation 'androidx.core:core-ktx:1.15.0'
   implementation 'androidx.appcompat:appcompat:1.7.0'

--- a/automatedtests/build.gradle
+++ b/automatedtests/build.gradle
@@ -3,13 +3,13 @@ apply plugin: 'com.android.application'
 
 android {
   namespace = "com.mux.player.media3"
-  compileSdk 35
+  compileSdk 36
 
   defaultConfig {
     applicationId "com.mux.player.media3"
     minSdkVersion 21
     //noinspection EditedTargetSdkVersion
-    targetSdk 35
+    targetSdk 36
     versionCode 1
     versionName "1.0"
     multiDexEnabled true
@@ -29,6 +29,7 @@ android {
     at_1_4 { dimension "media3" }
     at_1_5 { dimension "media3" }
     at_1_6 { dimension "media3" }
+    at_1_8 { dimension "media3" }
   }
 
   buildFeatures {
@@ -179,13 +180,28 @@ dependencies {
   //noinspection GradleDependency
   at_1_6Implementation "androidx.media3:media3-exoplayer-rtsp:1.6.0"
 
-  At_latestImplementation "androidx.media3:media3-exoplayer:1.6.0"
-  At_latestImplementation "androidx.media3:media3-session:1.6.0"
-  At_latestImplementation "androidx.media3:media3-ui:1.6.0"
-  At_latestImplementation "androidx.media3:media3-exoplayer-ima:1.6.0"
-  At_latestImplementation "androidx.media3:media3-exoplayer-dash:1.6.0"
-  At_latestImplementation "androidx.media3:media3-exoplayer-hls:1.6.0"
-  At_latestImplementation "androidx.media3:media3-exoplayer-rtsp:1.6.0"
+  //noinspection GradleDependency
+  at_1_8Implementation "androidx.media3:media3-exoplayer:1.8.0"
+  //noinspection GradleDependency
+  at_1_8Implementation "androidx.media3:media3-session:1.8.0"
+  //noinspection GradleDependency
+  at_1_8Implementation "androidx.media3:media3-ui:1.8.0"
+  //noinspection GradleDependency
+  at_1_8Implementation "androidx.media3:media3-exoplayer-ima:1.8.0"
+  //noinspection GradleDependency
+  at_1_8Implementation "androidx.media3:media3-exoplayer-dash:1.8.0"
+  //noinspection GradleDependency
+  at_1_8Implementation "androidx.media3:media3-exoplayer-hls:1.8.0"
+  //noinspection GradleDependency
+  at_1_8Implementation "androidx.media3:media3-exoplayer-rtsp:1.8.0"
+
+  At_latestImplementation "androidx.media3:media3-exoplayer:1.8.0"
+  At_latestImplementation "androidx.media3:media3-session:1.8.0"
+  At_latestImplementation "androidx.media3:media3-ui:1.8.0"
+  At_latestImplementation "androidx.media3:media3-exoplayer-ima:1.8.0"
+  At_latestImplementation "androidx.media3:media3-exoplayer-dash:1.8.0"
+  At_latestImplementation "androidx.media3:media3-exoplayer-hls:1.8.0"
+  At_latestImplementation "androidx.media3:media3-exoplayer-rtsp:1.8.0"
 
   androidTestImplementation 'androidx.test:runner:1.5.2'
   androidTestImplementation 'androidx.test:rules:1.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 allprojects {
   project.ext {
     androidCoreVersion = '1.4.11'
-    javaCoreVersion = '8.5.0'
+    javaCoreVersion = '8.5.1'
   }
 
   tasks.withType(DokkaTaskPartial.class) {

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
   namespace 'com.mux.stats.sdk.muxstats.media3_exo'
-  compileSdk 35
+  compileSdk 36
 
   buildFeatures {
     buildConfig = true
@@ -50,6 +50,9 @@ android {
       dimension "media3"
     }
     at_1_6 {
+      dimension "media3"
+    }
+    at_1_8 {
       dimension "media3"
     }
   }
@@ -155,9 +158,14 @@ dependencies {
   at_1_6CompileOnly "androidx.media3:media3-exoplayer-hls:1.6.0"
 
   //noinspection GradleDependency
-  At_latestApi "androidx.media3:media3-exoplayer:1.6.0"
+  at_1_8Api "androidx.media3:media3-exoplayer:1.8.0"
   //noinspection GradleDependency
-  At_latestCompileOnly "androidx.media3:media3-exoplayer-hls:1.6.0"
+  at_1_8CompileOnly "androidx.media3:media3-exoplayer-hls:1.8.0"
+
+  //noinspection GradleDependency
+  At_latestApi "androidx.media3:media3-exoplayer:1.8.0"
+  //noinspection GradleDependency
+  At_latestCompileOnly "androidx.media3:media3-exoplayer-hls:1.8.0"
 
   testImplementation 'junit:junit:4.13.2'
   androidTestImplementation 'androidx.test.ext:junit:1.2.1'

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
   namespace 'com.mux.stats.sdk.media3_ima'
-  compileSdk 35
+  compileSdk 36
 
   buildFeatures {
     buildConfig = true
@@ -36,11 +36,11 @@ android {
       minSdk 19 // minSdk is 19 before 1.4
     }
     at_1_2 {
-     dimension "media3"
+      dimension "media3"
       minSdk 19 // minSdk is 19 before 1.4
      }
     at_1_3 {
-     dimension "media3"
+      dimension "media3"
       minSdk 19 // minSdk is 19 before 1.4
      }
     at_1_4 {
@@ -50,6 +50,9 @@ android {
       dimension "media3"
     }
     at_1_6 {
+      dimension "media3"
+    }
+    at_1_8 {
       dimension "media3"
     }
   }
@@ -121,6 +124,7 @@ dependencies {
 
   //noinspection GradleDependency
   at_1_0Api "androidx.media3:media3-exoplayer-ima:1.0.0"
+  //noinspection GradleDependency
   at_1_0Api "androidx.media3:media3-exoplayer:1.0.0"
   //noinspection GradleDependency
   at_1_1Api "androidx.media3:media3-exoplayer-ima:1.1.1"
@@ -147,9 +151,14 @@ dependencies {
   //noinspection GradleDependency
   at_1_6Api "androidx.media3:media3-exoplayer-ima:1.6.0"
   //noinspection GradleDependency
-  At_latestApi "androidx.media3:media3-exoplayer-ima:1.6.0"
+  at_1_8Api "androidx.media3:media3-exoplayer:1.8.0"
   //noinspection GradleDependency
-  At_latestApi "androidx.media3:media3-exoplayer:1.6.0"
+  at_1_8Api "androidx.media3:media3-exoplayer-ima:1.8.0"
+
+  //noinspection GradleDependency
+  At_latestApi "androidx.media3:media3-exoplayer-ima:1.8.0"
+  //noinspection GradleDependency
+  At_latestApi "androidx.media3:media3-exoplayer:1.8.0"
 
   implementation 'androidx.core:core-ktx:1.15.0'
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
   namespace 'com.mux.stats.sdk.muxstats.media3'
-  compileSdk 35
+  compileSdk 36
 
   buildFeatures {
     buildConfig = true
@@ -49,6 +49,9 @@ android {
       dimension "media3"
     }
     at_1_6 {
+      dimension "media3"
+    }
+    at_1_8 {
       dimension "media3"
     }
   }
@@ -134,7 +137,9 @@ dependencies {
   //noinspection GradleDependency // benefit from optimistic matching
   at_1_6Api "androidx.media3:media3-common:1.6.0"
   //noinspection GradleDependency // benefit from optimistic matching
-  At_latestApi "androidx.media3:media3-common:1.6.0"
+  at_1_8Api "androidx.media3:media3-common:1.8.0"
+  //noinspection GradleDependency // benefit from optimistic matching
+  At_latestApi "androidx.media3:media3-common:1.8.0"
 
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1"
 


### PR DESCRIPTION
## Updates
* Add support for media3 v1.8 (#123)

## Fixes
* Un-deprecate `CustomerVideoData.videoCdn`

### Internal lib updates
* Update `stats.muxcore` to v8.5.1



Co-authored-by: Emily Dixon <edixon@mux.com>
Co-authored-by: GitHub <noreply@github.com>