### PR TITLE
Update Kotlin version, Gradle, ktx dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.iml
 .gradle
 .idea
+.kotlin
 /local.properties
 /.idea/caches
 /.idea/libraries

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
   id 'com.android.application'
   id 'org.jetbrains.kotlin.android'
+  id "org.jetbrains.kotlin.plugin.compose"
 }
 
 android {
@@ -97,14 +98,14 @@ dependencies {
   implementation project(":library-ima")
   implementation project(":library-exo")
   implementation project(":library")
-  implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
-  implementation 'androidx.activity:activity-compose:1.8.2'
-  implementation platform('androidx.compose:compose-bom:2023.08.00')
+  implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.9.2'
+  implementation 'androidx.activity:activity-compose:1.10.1'
+  implementation platform('androidx.compose:compose-bom:2025.08.00')
   implementation 'androidx.compose.ui:ui'
   implementation 'androidx.compose.ui:ui-graphics'
   implementation 'androidx.compose.ui:ui-tooling-preview'
   implementation 'androidx.compose.material3:material3'
-  androidTestImplementation platform('androidx.compose:compose-bom:2023.08.00')
+  androidTestImplementation platform('androidx.compose:compose-bom:2025.08.00')
   androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
 
   //noinspection GradleDependency
@@ -235,13 +236,13 @@ dependencies {
   At_latestImplementation "androidx.media3:media3-exoplayer-hls:1.8.0"
   At_latestImplementation "androidx.media3:media3-exoplayer-rtsp:1.8.0"
 
-  implementation 'androidx.core:core-ktx:1.15.0'
-  implementation 'androidx.appcompat:appcompat:1.7.0'
+  implementation 'androidx.core:core-ktx:1.17.0'
+  implementation 'androidx.appcompat:appcompat:1.7.1'
   implementation 'com.google.android.material:material:1.12.0'
-  implementation 'androidx.constraintlayout:constraintlayout:2.2.0'
+  implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
   testImplementation 'junit:junit:4.13.2'
-  androidTestImplementation 'androidx.test.ext:junit:1.2.1'
-  androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+  androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+  androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
   debugImplementation 'androidx.compose.ui:ui-tooling'
   debugImplementation 'androidx.compose.ui:ui-test-manifest'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,12 +5,12 @@ plugins {
 
 android {
   namespace 'com.mux.stats.muxdatasdkformedia3'
-  compileSdk 36
+  compileSdk = 36
 
   defaultConfig {
     applicationId "com.example.muxdatasdkformedia3"
     //noinspection OldTargetApi
-    targetSdk 35
+    targetSdk 36
     minSdk 21
     versionCode 1
     def commit = "git rev-parse --short HEAD".execute().inputReader().readLines().join()

--- a/automatedtests/build.gradle
+++ b/automatedtests/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 
 android {
   namespace = "com.mux.player.media3"
-  compileSdk 36
+  compileSdk = 36
 
   defaultConfig {
     applicationId "com.mux.player.media3"

--- a/automatedtests/build.gradle
+++ b/automatedtests/build.gradle
@@ -69,11 +69,11 @@ android {
 
 dependencies {
   implementation fileTree(dir: "libs", include: ["*.jar"])
-  implementation 'androidx.appcompat:appcompat:1.4.0'
-  implementation 'com.google.android.material:material:1.9.0'
-  implementation 'androidx.constraintlayout:constraintlayout:2.0.3'
-  implementation 'androidx.navigation:navigation-fragment:2.5.3'
-  implementation 'androidx.navigation:navigation-ui:2.5.3'
+  implementation 'androidx.appcompat:appcompat:1.7.1'
+  implementation 'com.google.android.material:material:1.12.0'
+  implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
+  implementation 'androidx.navigation:navigation-fragment:2.9.3'
+  implementation 'androidx.navigation:navigation-ui:2.9.3'
 
   //noinspection GradleDependency
   at_1_0Implementation "androidx.media3:media3-exoplayer:1.0.0"
@@ -203,17 +203,17 @@ dependencies {
   At_latestImplementation "androidx.media3:media3-exoplayer-hls:1.8.0"
   At_latestImplementation "androidx.media3:media3-exoplayer-rtsp:1.8.0"
 
-  androidTestImplementation 'androidx.test:runner:1.5.2'
-  androidTestImplementation 'androidx.test:rules:1.3.0'
+  androidTestImplementation 'androidx.test:runner:1.7.0'
+  androidTestImplementation 'androidx.test:rules:1.7.0'
   // Optional -- Hamcrest library
-  androidTestImplementation 'org.hamcrest:hamcrest-library:1.3'
+  androidTestImplementation 'org.hamcrest:hamcrest-library:3.0'
   // Optional -- UI testing with Espresso
-  androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+  androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
   // Optional -- UI testing with UI Automator
-  androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
-  androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+  androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.3.0'
+  androidTestImplementation 'androidx.test.ext:junit:1.3.0'
 
-  api 'org.checkerframework:checker-qual:3.33.0'
+  api 'org.checkerframework:checker-qual:3.49.5'
 
   // Automated tests should always test the local module and not the maven dependency.
   implementation project(":library")

--- a/automatedtests/src/androidTest/java/com/mux/player/media3/automatedtests/AdsPlaybackTests.java
+++ b/automatedtests/src/androidTest/java/com/mux/player/media3/automatedtests/AdsPlaybackTests.java
@@ -3,7 +3,6 @@ package com.mux.player.media3.automatedtests;
 
 import static org.junit.Assert.fail;
 
-import androidx.test.uiautomator.v18.BuildConfig;
 import com.mux.player.media3.automatedtests.mockup.http.SimpleHTTPServer;
 import com.mux.stats.sdk.core.events.playback.AdBreakEndEvent;
 import com.mux.stats.sdk.core.events.playback.AdBreakStartEvent;

--- a/automatedtests/src/androidTest/java/com/mux/player/media3/automatedtests/MissusageTests.java
+++ b/automatedtests/src/androidTest/java/com/mux/player/media3/automatedtests/MissusageTests.java
@@ -3,7 +3,8 @@ package com.mux.player.media3.automatedtests;
 import static org.junit.Assert.fail;
 
 import androidx.media3.exoplayer.ExoPlayer;
-import androidx.test.uiautomator.v18.BuildConfig;
+
+import com.mux.player.media3.BuildConfig;
 import com.mux.player.media3.automatedtests.mockup.http.SimpleHTTPServer;
 import com.mux.stats.sdk.core.events.playback.PlayEvent;
 import com.mux.stats.sdk.core.events.playback.PlayingEvent;

--- a/automatedtests/src/androidTest/java/com/mux/player/media3/automatedtests/PlaybackTests.java
+++ b/automatedtests/src/androidTest/java/com/mux/player/media3/automatedtests/PlaybackTests.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.fail;
 import android.util.Log;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
-import androidx.test.uiautomator.v18.BuildConfig;
 import com.mux.stats.sdk.core.events.playback.EndedEvent;
 import com.mux.stats.sdk.core.events.playback.PauseEvent;
 import com.mux.stats.sdk.core.events.playback.PlayEvent;

--- a/automatedtests/src/androidTest/java/com/mux/player/media3/automatedtests/TestBase.java
+++ b/automatedtests/src/androidTest/java/com/mux/player/media3/automatedtests/TestBase.java
@@ -22,7 +22,8 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 import androidx.test.uiautomator.UiDevice;
-import androidx.test.uiautomator.v18.BuildConfig;
+
+import com.mux.player.media3.BuildConfig;
 import com.mux.player.media3.R;
 import com.mux.player.media3.automatedtests.mockup.MockNetworkRequest;
 import com.mux.player.media3.automatedtests.mockup.http.SimpleHTTPServer;

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,8 @@ import org.jetbrains.dokka.gradle.DokkaTaskPartial
 plugins {
   id 'com.android.application' version '8.12.1' apply false
   id 'com.android.library' version '8.12.1' apply false
-  id 'org.jetbrains.kotlin.android' version '1.9.24' apply false
+  id 'org.jetbrains.kotlin.android' version '2.2.10' apply false
+  id "org.jetbrains.kotlin.plugin.compose" version "2.2.10"
   id 'com.mux.gradle.android.mux-android-distribution' version '1.3.0' apply false
   id "org.jetbrains.dokka" version "1.6.10"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
 plugins {
-  id 'com.android.application' version '8.8.2' apply false
-  id 'com.android.library' version '8.8.2' apply false
+  id 'com.android.application' version '8.12.1' apply false
+  id 'com.android.library' version '8.12.1' apply false
   id 'org.jetbrains.kotlin.android' version '1.9.24' apply false
   id 'com.mux.gradle.android.mux-android-distribution' version '1.3.0' apply false
   id "org.jetbrains.dokka" version "1.6.10"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Nov 18 08:57:39 PST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
   namespace 'com.mux.stats.sdk.muxstats.media3_exo'
-  compileSdk 36
+  compileSdk = 36
 
   buildFeatures {
     buildConfig = true

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -168,8 +168,8 @@ dependencies {
   At_latestCompileOnly "androidx.media3:media3-exoplayer-hls:1.8.0"
 
   testImplementation 'junit:junit:4.13.2'
-  androidTestImplementation 'androidx.test.ext:junit:1.2.1'
-  androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+  androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+  androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 }
 
 afterEvaluate {

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
   namespace 'com.mux.stats.sdk.media3_ima'
-  compileSdk 36
+  compileSdk = 36
 
   buildFeatures {
     buildConfig = true
@@ -160,15 +160,15 @@ dependencies {
   //noinspection GradleDependency
   At_latestApi "androidx.media3:media3-exoplayer:1.8.0"
 
-  implementation 'androidx.core:core-ktx:1.15.0'
+  implementation 'androidx.core:core-ktx:1.17.0'
 
   testImplementation 'junit:junit:4.13.2'
-  testImplementation 'androidx.test.ext:junit:1.2.1'
-  testImplementation "io.mockk:mockk:1.12.3"
-  testImplementation 'org.robolectric:robolectric:4.11.1'
+  testImplementation 'androidx.test.ext:junit:1.3.0'
+  testImplementation "io.mockk:mockk:1.14.5"
+  testImplementation 'org.robolectric:robolectric:4.15.1'
 
-  androidTestImplementation 'androidx.test.ext:junit:1.2.1'
-  androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+  androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+  androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 }
 
 afterEvaluate {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 android {
   namespace 'com.mux.stats.sdk.muxstats.media3'
-  compileSdk 36
+  compileSdk = 36
 
   buildFeatures {
     buildConfig = true

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -141,13 +141,13 @@ dependencies {
   //noinspection GradleDependency // benefit from optimistic matching
   At_latestApi "androidx.media3:media3-common:1.8.0"
 
-  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1"
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2"
 
   testImplementation 'junit:junit:4.13.2'
-  testImplementation 'androidx.test.ext:junit:1.2.1'
-  testImplementation "io.mockk:mockk:1.12.3"
-  testImplementation 'org.robolectric:robolectric:4.11.1'
+  testImplementation 'androidx.test.ext:junit:1.3.0'
+  testImplementation "io.mockk:mockk:1.14.5"
+  testImplementation 'org.robolectric:robolectric:4.15.1'
 
-  androidTestImplementation 'androidx.test.ext:junit:1.2.1'
-  androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+  androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+  androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 }


### PR DESCRIPTION
## SDK-affecting changes

* Update Kotlin from 1.9 to 2.2.10. 
  * Beginning to find warnings and problems with dependency updates for 1.9
  * Probably not going to cause customer problems, there's good backward compatibility
* Update `kotlinx` core and coroutine libraries
  * Usually they're backward compatible, and the customer build can override these anyway
  
  ## Other changes
  * Update Compose in the example app
  * Update Gradle and the the Android Gradle Plugin