### PR TITLE
Releaes/v1.11.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 allprojects {
   project.ext {
-    androidCoreVersion = '1.7.0'
-    javaCoreVersion = '8.8.0'
+    androidCoreVersion = '1.7.2'
+    javaCoreVersion = '8.9.0'
   }
 
   tasks.withType(DokkaTaskPartial.class) {


### PR DESCRIPTION
## New 
* Track which sections of content a user has watched
* Track mid-view changes to network type and send `networkchange` events

## Improvements
* Send `"no_connection"` as a network connection type if connectivity is momentarily lost during a stream

### Internal Lib Updates

Update muxstats:android to 1.7.2 and stats.muxcore to 8.9.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes version pins in `build.gradle`; no production logic changes, with risk limited to potential dependency compatibility/regressions.
> 
> **Overview**
> Bumps internal library versions by updating Gradle project extension properties: `androidCoreVersion` from `1.7.0` to `1.7.2` and `javaCoreVersion` from `8.8.0` to `8.9.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 615c29f9d01bad46b243ee235006b26522ee2bad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Improvements

* Update muxstats:android to 1.7.2 and stats.muxcore to 8.9.0



Co-authored-by: Emily Dixon <edixon@mux.com>