### PR TITLE
Releases/v1.11.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,7 @@ android {
     at_1_6 { dimension "media3" }
     at_1_8 { dimension "media3" }
     at_1_9 { dimension "media3" }
+    at_1_10 { dimension "media3" }
   }
 
   sourceSets {
@@ -67,6 +68,9 @@ android {
       java.srcDirs += "src/compatFrom1_3/java"
     }
     at_1_9 {
+      java.srcDirs += "src/compatFrom1_3/java"
+    }
+    at_1_10 {
       java.srcDirs += "src/compatFrom1_3/java"
     }
   }
@@ -250,13 +254,28 @@ dependencies {
   //noinspection GradleDependency
   at_1_9Implementation "androidx.media3:media3-exoplayer-rtsp:1.9.0"
 
-  At_latestImplementation "androidx.media3:media3-exoplayer:1.9.0"
-  At_latestImplementation "androidx.media3:media3-session:1.9.0"
-  At_latestImplementation "androidx.media3:media3-ui:1.9.0"
-  At_latestImplementation "androidx.media3:media3-exoplayer-ima:1.9.0"
-  At_latestImplementation "androidx.media3:media3-exoplayer-dash:1.9.0"
-  At_latestImplementation "androidx.media3:media3-exoplayer-hls:1.9.0"
-  At_latestImplementation "androidx.media3:media3-exoplayer-rtsp:1.9.0"
+  //noinspection GradleDependency
+  at_1_10Implementation "androidx.media3:media3-exoplayer:1.10.0"
+  //noinspection GradleDependency
+  at_1_10Implementation "androidx.media3:media3-session:1.10.0"
+  //noinspection GradleDependency
+  at_1_10Implementation "androidx.media3:media3-ui:1.10.0"
+  //noinspection GradleDependency
+  at_1_10Implementation "androidx.media3:media3-exoplayer-ima:1.10.0"
+  //noinspection GradleDependency
+  at_1_10Implementation "androidx.media3:media3-exoplayer-dash:1.10.0"
+  //noinspection GradleDependency
+  at_1_10Implementation "androidx.media3:media3-exoplayer-hls:1.10.0"
+  //noinspection GradleDependency
+  at_1_10Implementation "androidx.media3:media3-exoplayer-rtsp:1.10.0"
+
+  At_latestImplementation "androidx.media3:media3-exoplayer:1.10.0"
+  At_latestImplementation "androidx.media3:media3-session:1.10.0"
+  At_latestImplementation "androidx.media3:media3-ui:1.10.0"
+  At_latestImplementation "androidx.media3:media3-exoplayer-ima:1.10.0"
+  At_latestImplementation "androidx.media3:media3-exoplayer-dash:1.10.0"
+  At_latestImplementation "androidx.media3:media3-exoplayer-hls:1.10.0"
+  At_latestImplementation "androidx.media3:media3-exoplayer-rtsp:1.10.0"
 
   implementation 'androidx.core:core-ktx:1.17.0'
   implementation 'androidx.appcompat:appcompat:1.7.1'

--- a/automatedtests/build.gradle
+++ b/automatedtests/build.gradle
@@ -31,6 +31,7 @@ android {
     at_1_6 { dimension "media3" }
     at_1_8 { dimension "media3" }
     at_1_9 { dimension "media3" }
+    at_1_10 { dimension "media3" }
   }
 
   buildFeatures {
@@ -214,13 +215,28 @@ dependencies {
   //noinspection GradleDependency
   at_1_9Implementation "androidx.media3:media3-exoplayer-rtsp:1.9.0"
 
-  At_latestImplementation "androidx.media3:media3-exoplayer:1.9.0"
-  At_latestImplementation "androidx.media3:media3-session:1.9.0"
-  At_latestImplementation "androidx.media3:media3-ui:1.9.0"
-  At_latestImplementation "androidx.media3:media3-exoplayer-ima:1.9.0"
-  At_latestImplementation "androidx.media3:media3-exoplayer-dash:1.9.0"
-  At_latestImplementation "androidx.media3:media3-exoplayer-hls:1.9.0"
-  At_latestImplementation "androidx.media3:media3-exoplayer-rtsp:1.9.0"
+  //noinspection GradleDependency
+  at_1_10Implementation "androidx.media3:media3-exoplayer:1.10.0"
+  //noinspection GradleDependency
+  at_1_10Implementation "androidx.media3:media3-session:1.10.0"
+  //noinspection GradleDependency
+  at_1_10Implementation "androidx.media3:media3-ui:1.10.0"
+  //noinspection GradleDependency
+  at_1_10Implementation "androidx.media3:media3-exoplayer-ima:1.10.0"
+  //noinspection GradleDependency
+  at_1_10Implementation "androidx.media3:media3-exoplayer-dash:1.10.0"
+  //noinspection GradleDependency
+  at_1_10Implementation "androidx.media3:media3-exoplayer-hls:1.10.0"
+  //noinspection GradleDependency
+  at_1_10Implementation "androidx.media3:media3-exoplayer-rtsp:1.10.0"
+
+  At_latestImplementation "androidx.media3:media3-exoplayer:1.10.0"
+  At_latestImplementation "androidx.media3:media3-session:1.10.0"
+  At_latestImplementation "androidx.media3:media3-ui:1.10.0"
+  At_latestImplementation "androidx.media3:media3-exoplayer-ima:1.10.0"
+  At_latestImplementation "androidx.media3:media3-exoplayer-dash:1.10.0"
+  At_latestImplementation "androidx.media3:media3-exoplayer-hls:1.10.0"
+  At_latestImplementation "androidx.media3:media3-exoplayer-rtsp:1.10.0"
 
   androidTestImplementation 'androidx.test:runner:1.7.0'
   androidTestImplementation 'androidx.test:rules:1.7.0'

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 allprojects {
   project.ext {
     androidCoreVersion = '1.7.2'
-    javaCoreVersion = '8.9.0'
+    javaCoreVersion = '8.9.'
   }
 
   tasks.withType(DokkaTaskPartial.class) {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 allprojects {
   project.ext {
     androidCoreVersion = '1.7.2'
-    javaCoreVersion = '8.9.'
+    javaCoreVersion = '8.9.2'
   }
 
   tasks.withType(DokkaTaskPartial.class) {

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -62,6 +62,9 @@ android {
     at_1_9 {
       dimension "media3"
     }
+    at_1_10 {
+      dimension "media3"
+    }
   }
 
   buildTypes {
@@ -175,9 +178,14 @@ dependencies {
   at_1_9CompileOnly "androidx.media3:media3-exoplayer-hls:1.9.0"
 
   //noinspection GradleDependency
-  At_latestApi "androidx.media3:media3-exoplayer:1.9.0"
+  at_1_10Api "androidx.media3:media3-exoplayer:1.10.0"
   //noinspection GradleDependency
-  At_latestCompileOnly "androidx.media3:media3-exoplayer-hls:1.9.0"
+  at_1_10CompileOnly "androidx.media3:media3-exoplayer-hls:1.10.0"
+
+  //noinspection GradleDependency
+  At_latestApi "androidx.media3:media3-exoplayer:1.10.0"
+  //noinspection GradleDependency
+  At_latestCompileOnly "androidx.media3:media3-exoplayer-hls:1.10.0"
 
   testImplementation 'junit:junit:4.13.2'
   androidTestImplementation 'androidx.test.ext:junit:1.3.0'

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -59,6 +59,9 @@ android {
       dimension "media3"
       minSdk = 21 // minSdk is 21 before 1.9
     }
+    at_1_10 {
+      dimension "media3"
+    }
     at_1_9 {
       dimension "media3"
     }
@@ -90,6 +93,9 @@ android {
       java.srcDirs += 'src/compatFrom_1_0/java'
     }
     at_1_9 {
+      java.srcDirs += 'src/compatFrom_1_9/java'
+    }
+    at_1_10 {
       java.srcDirs += 'src/compatFrom_1_9/java'
     }
     At_latest {
@@ -201,11 +207,15 @@ dependencies {
   at_1_9Api "androidx.media3:media3-exoplayer:1.9.0"
   //noinspection GradleDependency
   at_1_9Api "androidx.media3:media3-exoplayer-ima:1.9.0"
+  //noinspection GradleDependency
+  at_1_10Api "androidx.media3:media3-exoplayer:1.10.0"
+  //noinspection GradleDependency
+  at_1_10Api "androidx.media3:media3-exoplayer-ima:1.10.0"
 
   //noinspection GradleDependency
-  At_latestApi "androidx.media3:media3-exoplayer-ima:1.9.0"
+  At_latestApi "androidx.media3:media3-exoplayer:1.10.0"
   //noinspection GradleDependency
-  At_latestApi "androidx.media3:media3-exoplayer:1.9.0"
+  At_latestApi "androidx.media3:media3-exoplayer-ima:1.10.0"
 
   implementation 'androidx.core:core-ktx:1.17.0'
 

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -59,10 +59,10 @@ android {
       dimension "media3"
       minSdk = 21 // minSdk is 21 before 1.9
     }
-    at_1_10 {
+    at_1_9 {
       dimension "media3"
     }
-    at_1_9 {
+    at_1_10 {
       dimension "media3"
     }
   }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -61,6 +61,9 @@ android {
     at_1_9 {
       dimension "media3"
     }
+    at_1_10 {
+      dimension "media3"
+    }
   }
 
   buildTypes {
@@ -148,7 +151,9 @@ dependencies {
   //noinspection GradleDependency // benefit from optimistic matching
   at_1_9Api "androidx.media3:media3-common:1.9.0"
   //noinspection GradleDependency // benefit from optimistic matching
-  At_latestApi "androidx.media3:media3-common:1.9.0"
+  at_1_10Api "androidx.media3:media3-common:1.10.0"
+  //noinspection GradleDependency // benefit from optimistic matching
+  At_latestApi "androidx.media3:media3-common:1.10.0"
 
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2"
 


### PR DESCRIPTION
## Updates
* Update json.org to version `20240303`
* Add support for media3 v1.10.x (#139)

### Internal Lib Updates

* update `stats.muxcore` to v8.9.2


Co-authored-by: Emily Dixon <edixon@mux.com>
Co-authored-by: GitHub <noreply@github.com>