### PR TITLE
NAT-373: pause/play/playing shouldn't be dispatched during ad breaks

### DIFF
--- a/library/src/main/java/com/mux/stats/sdk/muxstats/PlayerUtils.kt
+++ b/library/src/main/java/com/mux/stats/sdk/muxstats/PlayerUtils.kt
@@ -94,6 +94,12 @@ fun MuxStateCollector.handlePlayWhenReady(
   @Player.State playbackState: Int
 ) {
   MuxLogger.d("PlayerUtils", "handlePlayWhenReady: Called. pwr is $playWhenReady")
+
+  if (muxPlayerState == MuxPlayerState.PLAYING_ADS) {
+    MuxLogger.d("PlayerUtils", "handlePlayWhenReady: Called during ad break. ignoring")
+    return
+  }
+
   if (playWhenReady) {
     MuxLogger.d("PlayerUtils", "handlePlayWhenReady: dispatching play")
     play()
@@ -150,12 +156,14 @@ fun MuxStateCollector.handleExoPlaybackState(
         seeked()
       }
 
-      // If playWhenReady && READY, we're playing or else we're paused
-      if (playWhenReady) {
-        MuxLogger.d(LOG_TAG, "entered READY && pwr is true, dispatching playing()")
-        playing()
-      } else if (muxPlayerState != MuxPlayerState.PAUSED) {
-        pause()
+      if (muxPlayerState != MuxPlayerState.PLAYING_ADS) {
+        // If playWhenReady && READY, we're playing or else we're paused
+        if (playWhenReady) {
+          MuxLogger.d(LOG_TAG, "entered READY && pwr is true, dispatching playing()")
+          playing()
+        } else if (muxPlayerState != MuxPlayerState.PAUSED) {
+          pause()
+        }
       }
     }
 
@@ -177,7 +185,7 @@ fun MuxStateCollector.handleExoPlaybackState(
 @JvmSynthetic
 fun MuxStateCollector.handleMediaItemChanged(mediaItem: MediaItem) {
   mediaItem.localConfiguration?.let { localConfig ->
-    val sourceUrl = localConfig.uri;
+    val sourceUrl = localConfig.uri
     val sourceDomain = sourceUrl.authority
     val videoData = VideoData().apply {
       videoSourceDomain = sourceDomain

--- a/library/src/main/java/com/mux/stats/sdk/muxstats/PlayerUtils.kt
+++ b/library/src/main/java/com/mux/stats/sdk/muxstats/PlayerUtils.kt
@@ -156,14 +156,12 @@ fun MuxStateCollector.handleExoPlaybackState(
         seeked()
       }
 
-      if (muxPlayerState != MuxPlayerState.PLAYING_ADS) {
-        // If playWhenReady && READY, we're playing or else we're paused
-        if (playWhenReady) {
-          MuxLogger.d(LOG_TAG, "entered READY && pwr is true, dispatching playing()")
-          playing()
-        } else if (muxPlayerState != MuxPlayerState.PAUSED) {
-          pause()
-        }
+      // If playWhenReady && READY, we're playing or else we're paused
+      if (playWhenReady) {
+        MuxLogger.d(LOG_TAG, "entered READY && pwr is true, dispatching playing()")
+        playing()
+      } else if (muxPlayerState != MuxPlayerState.PAUSED) {
+        pause()
       }
     }
 

--- a/library/src/test/java/com/mux/stats/sdk/muxstats/PlayerUtilsTests.kt
+++ b/library/src/test/java/com/mux/stats/sdk/muxstats/PlayerUtilsTests.kt
@@ -9,6 +9,7 @@ import androidx.media3.common.Player.DISCONTINUITY_REASON_SEEK_ADJUSTMENT
 import androidx.media3.common.Player.DISCONTINUITY_REASON_SKIP
 import androidx.media3.common.Player.DiscontinuityReason
 import androidx.media3.common.Player.STATE_IDLE
+import com.mux.android.util.oneOf
 import com.mux.core_android.test.tools.log
 import com.mux.stats.media3.test.tools.AbsRobolectricTest
 import io.mockk.every
@@ -52,6 +53,7 @@ class PlayerUtilsTests : AbsRobolectricTest() {
       val mockStateCollector = mockk<MuxStateCollector> {
         every { play() } just runs
         every { playing() } just runs
+        every { muxPlayerState } returns MuxPlayerState.INIT
       }
       mockStateCollector.handlePlayWhenReady(true, playerState)
       verify { mockStateCollector.play() }
@@ -77,7 +79,7 @@ class PlayerUtilsTests : AbsRobolectricTest() {
 
       mockStateCollector.handlePlayWhenReady(false, dummyPlayerState)
 
-      val times = if (from == MuxPlayerState.PAUSED) 0 else 1
+      val times = if (from.oneOf(MuxPlayerState.PAUSED, MuxPlayerState.PLAYING_ADS)) 0 else 1
       verify(exactly = times) { mockStateCollector.pause() }
     }
 


### PR DESCRIPTION
Once suppressed, normal adpause/adplay/adplaying events are sent as expected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes playback state dispatch logic to ignore `playWhenReady` transitions during ad breaks, which may affect analytics event ordering/state transitions if ad detection is incorrect.
> 
> **Overview**
> Prevents `handlePlayWhenReady` from dispatching normal `play()`/`playing()`/`pause()` events while `muxPlayerState` is `PLAYING_ADS`, aligning behavior with existing ad-break suppression in `handleExoPlaybackState`.
> 
> Updates unit tests to account for the new ad-break guard (including not calling `pause()` when `muxPlayerState` is `PLAYING_ADS`) and adds the required `muxPlayerState` stubbing; also includes a minor Kotlin cleanup in `handleMediaItemChanged`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ab2e31338384b66316ea062606263b7ed60991d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->