### PR TITLE
Releases/v1.11.3

### DIFF
--- a/library/src/main/java/com/mux/stats/sdk/muxstats/PlayerUtils.kt
+++ b/library/src/main/java/com/mux/stats/sdk/muxstats/PlayerUtils.kt
@@ -94,6 +94,12 @@ fun MuxStateCollector.handlePlayWhenReady(
   @Player.State playbackState: Int
 ) {
   MuxLogger.d("PlayerUtils", "handlePlayWhenReady: Called. pwr is $playWhenReady")
+
+  if (muxPlayerState == MuxPlayerState.PLAYING_ADS) {
+    MuxLogger.d("PlayerUtils", "handlePlayWhenReady: Called during ad break. ignoring")
+    return
+  }
+
   if (playWhenReady) {
     MuxLogger.d("PlayerUtils", "handlePlayWhenReady: dispatching play")
     play()
@@ -177,7 +183,7 @@ fun MuxStateCollector.handleExoPlaybackState(
 @JvmSynthetic
 fun MuxStateCollector.handleMediaItemChanged(mediaItem: MediaItem) {
   mediaItem.localConfiguration?.let { localConfig ->
-    val sourceUrl = localConfig.uri;
+    val sourceUrl = localConfig.uri
     val sourceDomain = sourceUrl.authority
     val videoData = VideoData().apply {
       videoSourceDomain = sourceDomain

--- a/library/src/test/java/com/mux/stats/sdk/muxstats/PlayerUtilsTests.kt
+++ b/library/src/test/java/com/mux/stats/sdk/muxstats/PlayerUtilsTests.kt
@@ -9,6 +9,7 @@ import androidx.media3.common.Player.DISCONTINUITY_REASON_SEEK_ADJUSTMENT
 import androidx.media3.common.Player.DISCONTINUITY_REASON_SKIP
 import androidx.media3.common.Player.DiscontinuityReason
 import androidx.media3.common.Player.STATE_IDLE
+import com.mux.android.util.oneOf
 import com.mux.core_android.test.tools.log
 import com.mux.stats.media3.test.tools.AbsRobolectricTest
 import io.mockk.every
@@ -52,6 +53,7 @@ class PlayerUtilsTests : AbsRobolectricTest() {
       val mockStateCollector = mockk<MuxStateCollector> {
         every { play() } just runs
         every { playing() } just runs
+        every { muxPlayerState } returns MuxPlayerState.INIT
       }
       mockStateCollector.handlePlayWhenReady(true, playerState)
       verify { mockStateCollector.play() }
@@ -77,7 +79,7 @@ class PlayerUtilsTests : AbsRobolectricTest() {
 
       mockStateCollector.handlePlayWhenReady(false, dummyPlayerState)
 
-      val times = if (from == MuxPlayerState.PAUSED) 0 else 1
+      val times = if (from.oneOf(MuxPlayerState.PAUSED, MuxPlayerState.PLAYING_ADS)) 0 else 1
       verify(exactly = times) { mockStateCollector.pause() }
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes state-transition handling around `playWhenReady` while ads are playing, which can affect analytics event ordering and pause/play reporting during ad breaks.
> 
> **Overview**
> Prevents `handlePlayWhenReady` from dispatching `play()`/`playing()`/`pause()` transitions when the collector is in `MuxPlayerState.PLAYING_ADS`, aligning `playWhenReady` handling with existing ad-break suppression in `handleExoPlaybackState`.
> 
> Updates unit tests to account for the new ad-break behavior (no `pause()` when `muxPlayerState` is `PLAYING_ADS`) and fixes a minor Kotlin style issue in `handleMediaItemChanged`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd55a495d4134daa5b1b55fbaa8426f9b890afdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Fixes

* NAT-373: pause/play/playing shouldn't be dispatched during ad breaks (#143)



Co-authored-by: Emily Dixon <edixon@mux.com>
Co-authored-by: GitHub <noreply@github.com>