### PR TITLE
Releases/v1.12.0

### DIFF
--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/basic/BasicPlayerActivity.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/basic/BasicPlayerActivity.kt
@@ -40,6 +40,7 @@ class BasicPlayerActivity : AppCompatActivity() {
 
     view.playerView.apply {
       setShowBuffering(SHOW_BUFFERING_WHEN_PLAYING)
+      setShowSubtitleButton(true)
     }
     window.addFlags(KEEP_SCREEN_ON)
   }

--- a/app/src/main/res/layout/activity_player.xml
+++ b/app/src/main/res/layout/activity_player.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".examples.basic.BasicPlayerActivity">
@@ -9,6 +10,7 @@
         android:id="@+id/player_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        app:show_subtitle_button="true"
         />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 allprojects {
   project.ext {
     androidCoreVersion = '1.7.2'
-    javaCoreVersion = '8.9.0'
+    javaCoreVersion = '8.10.0'
   }
 
   tasks.withType(DokkaTaskPartial.class) {

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -180,6 +180,7 @@ dependencies {
   At_latestCompileOnly "androidx.media3:media3-exoplayer-hls:1.9.0"
 
   testImplementation 'junit:junit:4.13.2'
+  testImplementation 'org.robolectric:robolectric:4.15.1'
   androidTestImplementation 'androidx.test.ext:junit:1.3.0'
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 }
@@ -202,4 +203,3 @@ afterEvaluate {
             project.dependencies.add(sourceSet.apiConfigurationName, depNotation)
           }
 }
-

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
@@ -1,7 +1,7 @@
 package com.mux.stats.sdk.muxstats
 
-import android.util.Log
 import androidx.annotation.OptIn
+import androidx.media3.common.C
 import androidx.media3.common.Format
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
@@ -16,6 +16,7 @@ import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.exoplayer.source.LoadEventInfo
 import androidx.media3.exoplayer.source.MediaLoadData
 import com.mux.android.util.weak
+import com.mux.stats.sdk.core.events.playback.TextTrackChangeEvent
 import com.mux.stats.sdk.core.util.MuxLogger
 import com.mux.stats.sdk.muxstats.bandwidth.BandwidthMetricDispatcher
 import com.mux.stats.sdk.muxstats.bandwidth.TrackedHeader
@@ -93,6 +94,15 @@ private class MuxAnalyticsListener(
 
   private val player by weak(player)
   private var lastVideoFormat: Format? = null
+  private val textTrackChangeReporter = TextTrackChangeReporter { state ->
+    collector.muxStats.textTrackChange(
+      state.enabled,
+      state.type,
+      state.format,
+      state.name,
+      state.language
+    )
+  }
 
   override fun onPlayWhenReadyChanged(
     eventTime: AnalyticsListener.EventTime,
@@ -130,6 +140,7 @@ private class MuxAnalyticsListener(
     mediaItem: MediaItem?,
     reason: Int
   ) {
+    textTrackChangeReporter.reset()
     mediaItem?.let { collector.handleMediaItemChanged(it) }
   }
 
@@ -174,9 +185,12 @@ private class MuxAnalyticsListener(
 
     player?.let {
       collector.watchPlayerPos(it)
-      collector.mediaHasVideoTrack = tracks.hasAtLeastOneVideoTrack()
     }
     bandwidthMetrics?.onTracksChanged(tracks)
+    collector.mediaHasVideoTrack = tracks.hasAtLeastOneVideoTrack()
+    if (eventTime.mediaPeriodId?.isInAdGroup() != true) {
+      textTrackChangeReporter.reportTracksChanged(tracks)
+    }
   }
 
   override fun onDownstreamFormatChanged(
@@ -310,3 +324,103 @@ private class MuxAnalyticsListener(
     MuxLogger.d(TAG, "Listening to ExoPlayer $player")
   }
 }
+
+internal data class TextTrackState(
+  val enabled: Boolean,
+  val type: String? = null,
+  val format: String? = null,
+  val name: String? = null,
+  val language: String? = null,
+)
+
+internal class TextTrackChangeReporter(
+  private val dispatch: (TextTrackState) -> Unit,
+) {
+  private var lastReportedState: TextTrackState? = null
+
+  fun reportTracksChanged(tracks: Tracks) {
+    val nextState = tracks.toTextTrackState()
+    if (nextState != lastReportedState) {
+      dispatch(nextState)
+      lastReportedState = nextState
+    }
+  }
+
+  fun reset() {
+    lastReportedState = null
+  }
+}
+
+internal fun Tracks.toTextTrackState(): TextTrackState {
+  val selectedTextTrackGroup = groups.firstOrNull {
+    it.type == C.TRACK_TYPE_TEXT && it.isSelected
+  } ?: return TextTrackState(enabled = false)
+
+  val selectedTrackIndex = selectedTextTrackGroup.findSelectedTrackIndex()
+    ?: return TextTrackState(enabled = false)
+  val format = selectedTextTrackGroup.getTrackFormat(selectedTrackIndex)
+
+  return TextTrackState(
+    enabled = true,
+    type = format.toTextTrackType(),
+    format = format.toTextTrackFormat(),
+    name = format.label.toMeaningfulValue(),
+    language = format.language.toMeaningfulLanguage(),
+  )
+}
+
+internal fun Tracks.Group.findSelectedTrackIndex(): Int? {
+  for (i in 0..<length) {
+    if (isTrackSelected(i)) {
+      return i
+    }
+  }
+
+  return null
+}
+
+private fun Format.toTextTrackType(): String? = when {
+  roleFlags.hasFlag(C.ROLE_FLAG_CAPTION) -> TextTrackChangeEvent.TEXT_TRACK_TYPE_CLOSED_CAPTIONS
+  roleFlags.hasFlag(C.ROLE_FLAG_SUBTITLE) -> TextTrackChangeEvent.TEXT_TRACK_TYPE_SUBTITLES
+  else -> null
+}
+
+private fun Format.toTextTrackFormat(): String? {
+  val values = buildList {
+    sampleMimeType?.toNormalizedLookupValue()?.let(::add)
+    containerMimeType?.toNormalizedLookupValue()?.let(::add)
+    codecs
+      ?.split(',')
+      ?.mapNotNull { it.toNormalizedLookupValue() }
+      ?.let(::addAll)
+  }
+
+  return when {
+    values.any { it == "text/vtt" || it == "application/x-mp4-vtt" || it.contains("wvtt") } ->
+      TextTrackChangeEvent.TEXT_TRACK_FORMAT_WEBVTT
+    values.any { it == "application/x-subrip" || it.contains("subrip") || it == "srt" } ->
+      TextTrackChangeEvent.TEXT_TRACK_FORMAT_SRT
+    values.any {
+      it == "application/cea-608" || it.contains("cea608") || it.contains("cea-608")
+        || it.contains("eia608") || it.contains("eia-608")
+    } -> TextTrackChangeEvent.TEXT_TRACK_FORMAT_CEA_608
+    values.any {
+      it == "application/cea-708" || it.contains("cea708") || it.contains("cea-708")
+        || it.contains("eia708") || it.contains("eia-708")
+    } -> TextTrackChangeEvent.TEXT_TRACK_FORMAT_CEA_708
+    else -> null
+  }
+}
+
+private fun String?.toMeaningfulLanguage(): String? = toMeaningfulValue()
+  ?.takeUnless { it.equals("und", ignoreCase = true) }
+
+private fun String?.toMeaningfulValue(): String? = this
+  ?.trim()
+  ?.takeUnless { it.isEmpty() }
+
+private fun String.toNormalizedLookupValue(): String? = trim()
+  .lowercase()
+  .takeUnless { it.isEmpty() }
+
+private fun Int.hasFlag(flag: Int): Boolean = this and flag != 0

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/internal/HlsUtils.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/internal/HlsUtils.kt
@@ -13,7 +13,7 @@ import com.mux.stats.sdk.muxstats.MuxStateCollector
  * HlsUtils.kt: Utility functions for working with HLS playlists in exoplayer
  */
 
-private val RX_PDT_TAG = """^#EXT-X-PROGRAM-DATE-TIME:(.*)$""".toRegex()
+private val RX_PDT_TAG by lazy { """^#EXT-X-PROGRAM-DATE-TIME:(.*)$""".toRegex() }
 
 // lazily-cached check for the HLS extension, which may not be available at runtime
 @OptIn(UnstableApi::class) // opting-in to HlsManifest

--- a/library-exo/src/test/java/com/mux/stats/sdk/muxstats/TextTrackChangeReporterTest.kt
+++ b/library-exo/src/test/java/com/mux/stats/sdk/muxstats/TextTrackChangeReporterTest.kt
@@ -1,0 +1,193 @@
+package com.mux.stats.sdk.muxstats
+
+import androidx.media3.common.C
+import androidx.media3.common.Format
+import androidx.media3.common.TrackGroup
+import androidx.media3.common.Tracks
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner::class)
+class TextTrackChangeReporterTest {
+
+  @Test
+  fun `selected text track is normalized with known values`() {
+    val tracks = tracksOf(
+      textGroup(
+        format = textFormat(
+          sampleMimeType = "text/vtt",
+          label = "English (SDH)",
+          language = "en-US",
+          roleFlags = C.ROLE_FLAG_CAPTION,
+        ),
+        selected = true,
+      )
+    )
+
+    val state = tracks.toTextTrackState()
+
+    assertEquals(
+      TextTrackState(
+        enabled = true,
+        type = "cc",
+        format = "webvtt",
+        name = "English (SDH)",
+        language = "en-us",
+      ),
+      state
+    )
+  }
+
+  @Test
+  fun `missing text selection normalizes to disabled with cleared metadata`() {
+    val tracks = tracksOf(
+      textGroup(
+        format = textFormat(
+          sampleMimeType = "application/cea-608",
+          label = "English",
+          language = "en",
+          roleFlags = C.ROLE_FLAG_SUBTITLE,
+        ),
+        selected = false,
+      )
+    )
+
+    val state = tracks.toTextTrackState()
+
+    assertEquals(TextTrackState(enabled = false), state)
+  }
+
+  @Test
+  fun `unknown format and non-meaningful fields are omitted`() {
+    val tracks = tracksOf(
+      textGroup(
+        format = textFormat(
+          sampleMimeType = "application/ttml+xml",
+          label = " ",
+          language = "und",
+          roleFlags = 0,
+        ),
+        selected = true,
+      )
+    )
+
+    val state = tracks.toTextTrackState()
+
+    assertEquals(true, state.enabled)
+    assertNull(state.type)
+    assertNull(state.format)
+    assertNull(state.name)
+    assertNull(state.language)
+  }
+
+  @Test
+  fun `known formats are mapped when detectable`() {
+    assertEquals(
+      "srt",
+      tracksOf(textGroup(textFormat(sampleMimeType = "application/x-subrip"), selected = true))
+        .toTextTrackState().format
+    )
+    assertEquals(
+      "cea-608",
+      tracksOf(textGroup(textFormat(sampleMimeType = "application/cea-608"), selected = true))
+        .toTextTrackState().format
+    )
+    assertEquals(
+      "cea-708",
+      tracksOf(textGroup(textFormat(sampleMimeType = "application/cea-708"), selected = true))
+        .toTextTrackState().format
+    )
+  }
+
+  @Test
+  fun `reporter dispatches initial state, dedupes repeats, and reports disable`() {
+    val reportedStates = mutableListOf<TextTrackState>()
+    val reporter = TextTrackChangeReporter { reportedStates += it }
+    val selectedTracks = tracksOf(
+      textGroup(
+        format = textFormat(
+          sampleMimeType = "text/vtt",
+          label = "English",
+          language = "en",
+          roleFlags = C.ROLE_FLAG_SUBTITLE,
+        ),
+        selected = true,
+      )
+    )
+    val disabledTracks = tracksOf(
+      textGroup(
+        format = textFormat(
+          sampleMimeType = "text/vtt",
+          label = "English",
+          language = "en",
+          roleFlags = C.ROLE_FLAG_SUBTITLE,
+        ),
+        selected = false,
+      )
+    )
+
+    reporter.reportTracksChanged(selectedTracks)
+    reporter.reportTracksChanged(selectedTracks)
+    reporter.reportTracksChanged(disabledTracks)
+
+    assertEquals(2, reportedStates.size)
+    assertEquals(
+      TextTrackState(
+        enabled = true,
+        type = "subtitles",
+        format = "webvtt",
+        name = "English",
+        language = "en",
+      ),
+      reportedStates[0]
+    )
+    assertEquals(TextTrackState(enabled = false), reportedStates[1])
+  }
+
+  @Test
+  fun `reporter reset allows same state to be emitted for a new view`() {
+    val reportedStates = mutableListOf<TextTrackState>()
+    val reporter = TextTrackChangeReporter { reportedStates += it }
+    val selectedTracks = tracksOf(
+      textGroup(
+        format = textFormat(sampleMimeType = "text/vtt", label = "English", language = "en"),
+        selected = true,
+      )
+    )
+
+    reporter.reportTracksChanged(selectedTracks)
+    reporter.reset()
+    reporter.reportTracksChanged(selectedTracks)
+
+    assertEquals(2, reportedStates.size)
+    assertEquals(reportedStates[0], reportedStates[1])
+  }
+
+  private fun tracksOf(vararg groups: Tracks.Group): Tracks = Tracks(groups.toList())
+
+  private fun textGroup(format: Format, selected: Boolean): Tracks.Group = Tracks.Group(
+    TrackGroup(format),
+    false,
+    intArrayOf(C.FORMAT_HANDLED),
+    booleanArrayOf(selected),
+  )
+
+  private fun textFormat(
+    sampleMimeType: String?,
+    codecs: String? = null,
+    label: String? = null,
+    language: String? = null,
+    roleFlags: Int = 0,
+  ): Format = Format.Builder()
+    .setSampleMimeType(sampleMimeType)
+    .setCodecs(codecs)
+    .setLabel(label)
+    .setLanguage(language)
+    .setRoleFlags(roleFlags)
+    .build()
+}


### PR DESCRIPTION
## New

* Track changes to text track selection and send `textttrackchange` events

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New playback analytics on every track change could affect event volume or timing; ad-skipping and dedupe limit noise, but behavior depends on ExoPlayer track selection edge cases covered partly by new unit tests.
> 
> **Overview**
> This release adds **caption/subtitle analytics** for Media3 ExoPlayer by watching `onTracksChanged`, normalizing the selected text track (type, format, label, language), deduplicating emissions, skipping ad periods, and resetting on media item changes before calling `textTrackChange` on the Mux stats layer. **Mux Java core** is bumped from `8.9.2` to `8.10.0`.
> 
> The basic sample app exposes the **subtitle control** on `PlayerView` (layout + `setShowSubtitleButton`). **HLS** PDT regex compilation is deferred with `lazy`. **Robolectric** unit tests cover text-track normalization and reporter behavior; `library-exo` gains that test dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70921786c437a353656890fb93a303813e8dce8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->