### PR TITLE
Migrate repo to use Version Catalogs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-  id 'com.android.application'
-  id 'org.jetbrains.kotlin.android'
-  id "org.jetbrains.kotlin.plugin.compose"
+  alias(libs.plugins.android.application)
+  alias(libs.plugins.kotlin.android)
+  alias(libs.plugins.kotlin.compose)
 }
 
 android {
@@ -94,7 +94,7 @@ android {
     jvmTarget = '1.8'
   }
   composeOptions {
-    kotlinCompilerExtensionVersion '1.5.14'
+    kotlinCompilerExtensionVersion libs.versions.kotlinComposeCompilerExt.get()
   }
   packaging {
     resources {
@@ -107,183 +107,47 @@ dependencies {
   implementation project(":library-ima")
   implementation project(":library-exo")
   implementation project(":library")
-  implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.9.2'
-  implementation 'androidx.activity:activity-compose:1.10.1'
-  implementation platform('androidx.compose:compose-bom:2025.08.00')
-  implementation 'androidx.compose.ui:ui'
-  implementation 'androidx.compose.ui:ui-graphics'
-  implementation 'androidx.compose.ui:ui-tooling-preview'
-  implementation 'androidx.compose.material3:material3'
-  androidTestImplementation platform('androidx.compose:compose-bom:2025.08.00')
-  androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
+  implementation libs.androidx.lifecycle.runtime.ktx
+  implementation libs.androidx.activity.compose
+  implementation platform(libs.androidx.compose.bom)
+  implementation libs.androidx.compose.ui
+  implementation libs.androidx.compose.ui.graphics
+  implementation libs.androidx.compose.ui.tooling.preview
+  implementation libs.androidx.compose.material3
+  androidTestImplementation platform(libs.androidx.compose.bom)
+  androidTestImplementation libs.androidx.compose.ui.test.junit4
 
-  coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
-
-  //noinspection GradleDependency
-  at_1_0Implementation "androidx.media3:media3-exoplayer:1.0.0"
-  //noinspection GradleDependency
-  at_1_0Implementation "androidx.media3:media3-session:1.0.0"
-  //noinspection GradleDependency
-  at_1_0Implementation "androidx.media3:media3-ui:1.0.0"
-  //noinspection GradleDependency
-  at_1_0Implementation "androidx.media3:media3-exoplayer-ima:1.0.0"
-  //noinspection GradleDependency
-  at_1_0Implementation "androidx.media3:media3-exoplayer-dash:1.0.0"
-  //noinspection GradleDependency
-  at_1_0Implementation "androidx.media3:media3-exoplayer-hls:1.0.0"
-  //noinspection GradleDependency
-  at_1_0Implementation "androidx.media3:media3-exoplayer-rtsp:1.0.0"
+  coreLibraryDesugaring libs.desugar.jdk.libs
 
   //noinspection GradleDependency
-  at_1_1Implementation "androidx.media3:media3-exoplayer:1.1.1"
+  at_1_0Implementation libs.bundles.media3.app.at10
   //noinspection GradleDependency
-  at_1_1Implementation "androidx.media3:media3-session:1.1.1"
+  at_1_1Implementation libs.bundles.media3.app.at11
   //noinspection GradleDependency
-  at_1_1Implementation "androidx.media3:media3-ui:1.1.1"
+  at_1_2Implementation libs.bundles.media3.app.at12
   //noinspection GradleDependency
-  at_1_1Implementation "androidx.media3:media3-exoplayer-ima:1.1.1"
+  at_1_3Implementation libs.bundles.media3.app.at13
   //noinspection GradleDependency
-  at_1_1Implementation "androidx.media3:media3-exoplayer-dash:1.1.1"
+  at_1_4Implementation libs.bundles.media3.app.at14
   //noinspection GradleDependency
-  at_1_1Implementation "androidx.media3:media3-exoplayer-hls:1.1.1"
+  at_1_5Implementation libs.bundles.media3.app.at15
   //noinspection GradleDependency
-  at_1_1Implementation "androidx.media3:media3-exoplayer-rtsp:1.1.1"
+  at_1_6Implementation libs.bundles.media3.app.at16
+  //noinspection GradleDependency
+  at_1_8Implementation libs.bundles.media3.app.at18
+  //noinspection GradleDependency
+  at_1_9Implementation libs.bundles.media3.app.at19
+  //noinspection GradleDependency
+  at_1_10Implementation libs.bundles.media3.app.at110
+  At_latestImplementation libs.bundles.media3.app.atLatest
 
-  //noinspection GradleDependency
-  at_1_2Implementation "androidx.media3:media3-exoplayer:1.2.0"
-  //noinspection GradleDependency
-  at_1_2Implementation "androidx.media3:media3-session:1.2.0"
-  //noinspection GradleDependency
-  at_1_2Implementation "androidx.media3:media3-ui:1.2.0"
-  //noinspection GradleDependency
-  at_1_2Implementation "androidx.media3:media3-exoplayer-ima:1.2.0"
-  //noinspection GradleDependency
-  at_1_2Implementation "androidx.media3:media3-exoplayer-dash:1.2.0"
-  //noinspection GradleDependency
-  at_1_2Implementation "androidx.media3:media3-exoplayer-hls:1.2.0"
-  //noinspection GradleDependency
-  at_1_2Implementation "androidx.media3:media3-exoplayer-rtsp:1.2.0"
-
-  //noinspection GradleDependency
-  at_1_3Implementation "androidx.media3:media3-exoplayer:1.3.0"
-  //noinspection GradleDependency
-  at_1_3Implementation "androidx.media3:media3-session:1.3.0"
-  //noinspection GradleDependency
-  at_1_3Implementation "androidx.media3:media3-ui:1.3.0"
-  //noinspection GradleDependency
-  at_1_3Implementation "androidx.media3:media3-exoplayer-ima:1.3.0"
-  //noinspection GradleDependency
-  at_1_3Implementation "androidx.media3:media3-exoplayer-dash:1.3.0"
-  //noinspection GradleDependency
-  at_1_3Implementation "androidx.media3:media3-exoplayer-hls:1.3.0"
-  //noinspection GradleDependency
-  at_1_3Implementation "androidx.media3:media3-exoplayer-rtsp:1.3.0"
-
-  //noinspection GradleDependency
-  at_1_4Implementation "androidx.media3:media3-exoplayer:1.4.1"
-  //noinspection GradleDependency
-  at_1_4Implementation "androidx.media3:media3-session:1.4.1"
-  //noinspection GradleDependency
-  at_1_4Implementation "androidx.media3:media3-ui:1.4.1"
-  //noinspection GradleDependency
-  at_1_4Implementation "androidx.media3:media3-exoplayer-ima:1.4.1"
-  //noinspection GradleDependency
-  at_1_4Implementation "androidx.media3:media3-exoplayer-dash:1.4.1"
-  //noinspection GradleDependency
-  at_1_4Implementation "androidx.media3:media3-exoplayer-hls:1.4.1"
-  //noinspection GradleDependency
-  at_1_4Implementation "androidx.media3:media3-exoplayer-rtsp:1.4.1"
-
-  //noinspection GradleDependency
-  at_1_5Implementation "androidx.media3:media3-exoplayer:1.5.0"
-  //noinspection GradleDependency
-  at_1_5Implementation "androidx.media3:media3-session:1.5.0"
-  //noinspection GradleDependency
-  at_1_5Implementation "androidx.media3:media3-ui:1.5.0"
-  //noinspection GradleDependency
-  at_1_5Implementation "androidx.media3:media3-exoplayer-ima:1.5.0"
-  //noinspection GradleDependency
-  at_1_5Implementation "androidx.media3:media3-exoplayer-dash:1.5.0"
-  //noinspection GradleDependency
-  at_1_5Implementation "androidx.media3:media3-exoplayer-hls:1.5.0"
-  //noinspection GradleDependency
-  at_1_5Implementation "androidx.media3:media3-exoplayer-rtsp:1.5.0"
-
-  //noinspection GradleDependency
-  at_1_6Implementation "androidx.media3:media3-exoplayer:1.6.0"
-  //noinspection GradleDependency
-  at_1_6Implementation "androidx.media3:media3-session:1.6.0"
-  //noinspection GradleDependency
-  at_1_6Implementation "androidx.media3:media3-ui:1.6.0"
-  //noinspection GradleDependency
-  at_1_6Implementation "androidx.media3:media3-exoplayer-ima:1.6.0"
-  //noinspection GradleDependency
-  at_1_6Implementation "androidx.media3:media3-exoplayer-dash:1.6.0"
-  //noinspection GradleDependency
-  at_1_6Implementation "androidx.media3:media3-exoplayer-hls:1.6.0"
-  //noinspection GradleDependency
-  at_1_6Implementation "androidx.media3:media3-exoplayer-rtsp:1.6.0"
-
-  //noinspection GradleDependency
-  at_1_8Implementation "androidx.media3:media3-exoplayer:1.8.0"
-  //noinspection GradleDependency
-  at_1_8Implementation "androidx.media3:media3-session:1.8.0"
-  //noinspection GradleDependency
-  at_1_8Implementation "androidx.media3:media3-ui:1.8.0"
-  //noinspection GradleDependency
-  at_1_8Implementation "androidx.media3:media3-exoplayer-ima:1.8.0"
-  //noinspection GradleDependency
-  at_1_8Implementation "androidx.media3:media3-exoplayer-dash:1.8.0"
-  //noinspection GradleDependency
-  at_1_8Implementation "androidx.media3:media3-exoplayer-hls:1.8.0"
-  //noinspection GradleDependency
-  at_1_8Implementation "androidx.media3:media3-exoplayer-rtsp:1.8.0"
-
-  //noinspection GradleDependency
-  at_1_9Implementation "androidx.media3:media3-exoplayer:1.9.0"
-  //noinspection GradleDependency
-  at_1_9Implementation "androidx.media3:media3-session:1.9.0"
-  //noinspection GradleDependency
-  at_1_9Implementation "androidx.media3:media3-ui:1.9.0"
-  //noinspection GradleDependency
-  at_1_9Implementation "androidx.media3:media3-exoplayer-ima:1.9.0"
-  //noinspection GradleDependency
-  at_1_9Implementation "androidx.media3:media3-exoplayer-dash:1.9.0"
-  //noinspection GradleDependency
-  at_1_9Implementation "androidx.media3:media3-exoplayer-hls:1.9.0"
-  //noinspection GradleDependency
-  at_1_9Implementation "androidx.media3:media3-exoplayer-rtsp:1.9.0"
-
-  //noinspection GradleDependency
-  at_1_10Implementation "androidx.media3:media3-exoplayer:1.10.0"
-  //noinspection GradleDependency
-  at_1_10Implementation "androidx.media3:media3-session:1.10.0"
-  //noinspection GradleDependency
-  at_1_10Implementation "androidx.media3:media3-ui:1.10.0"
-  //noinspection GradleDependency
-  at_1_10Implementation "androidx.media3:media3-exoplayer-ima:1.10.0"
-  //noinspection GradleDependency
-  at_1_10Implementation "androidx.media3:media3-exoplayer-dash:1.10.0"
-  //noinspection GradleDependency
-  at_1_10Implementation "androidx.media3:media3-exoplayer-hls:1.10.0"
-  //noinspection GradleDependency
-  at_1_10Implementation "androidx.media3:media3-exoplayer-rtsp:1.10.0"
-
-  At_latestImplementation "androidx.media3:media3-exoplayer:1.10.0"
-  At_latestImplementation "androidx.media3:media3-session:1.10.0"
-  At_latestImplementation "androidx.media3:media3-ui:1.10.0"
-  At_latestImplementation "androidx.media3:media3-exoplayer-ima:1.10.0"
-  At_latestImplementation "androidx.media3:media3-exoplayer-dash:1.10.0"
-  At_latestImplementation "androidx.media3:media3-exoplayer-hls:1.10.0"
-  At_latestImplementation "androidx.media3:media3-exoplayer-rtsp:1.10.0"
-
-  implementation 'androidx.core:core-ktx:1.17.0'
-  implementation 'androidx.appcompat:appcompat:1.7.1'
-  implementation 'com.google.android.material:material:1.12.0'
-  implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
-  testImplementation 'junit:junit:4.13.2'
-  androidTestImplementation 'androidx.test.ext:junit:1.3.0'
-  androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
-  debugImplementation 'androidx.compose.ui:ui-tooling'
-  debugImplementation 'androidx.compose.ui:ui-test-manifest'
+  implementation libs.androidx.core.ktx
+  implementation libs.androidx.appcompat
+  implementation libs.material
+  implementation libs.androidx.constraintlayout
+  testImplementation libs.junit
+  androidTestImplementation libs.androidx.test.junit
+  androidTestImplementation libs.androidx.test.espresso.core
+  debugImplementation libs.androidx.compose.ui.tooling
+  debugImplementation libs.androidx.compose.ui.test.manifest
 }

--- a/automatedtests/build.gradle
+++ b/automatedtests/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'com.android.application'
+plugins {
+  alias(libs.plugins.android.application)
+}
 
 
 android {
@@ -72,183 +74,47 @@ android {
 
 dependencies {
   implementation fileTree(dir: "libs", include: ["*.jar"])
-  implementation 'androidx.appcompat:appcompat:1.7.1'
-  implementation 'com.google.android.material:material:1.12.0'
-  implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
-  implementation 'androidx.navigation:navigation-fragment:2.9.3'
-  implementation 'androidx.navigation:navigation-ui:2.9.3'
+  implementation libs.androidx.appcompat
+  implementation libs.material
+  implementation libs.androidx.constraintlayout
+  implementation libs.androidx.navigation.fragment
+  implementation libs.androidx.navigation.ui
 
-  coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
-
-  //noinspection GradleDependency
-  at_1_0Implementation "androidx.media3:media3-exoplayer:1.0.0"
-  //noinspection GradleDependency
-  at_1_0Implementation "androidx.media3:media3-session:1.0.0"
-  //noinspection GradleDependency
-  at_1_0Implementation "androidx.media3:media3-ui:1.0.0"
-  //noinspection GradleDependency
-  at_1_0Implementation "androidx.media3:media3-exoplayer-ima:1.0.0"
-  //noinspection GradleDependency
-  at_1_0Implementation "androidx.media3:media3-exoplayer-dash:1.0.0"
-  //noinspection GradleDependency
-  at_1_0Implementation "androidx.media3:media3-exoplayer-hls:1.0.0"
-  //noinspection GradleDependency
-  at_1_0Implementation "androidx.media3:media3-exoplayer-rtsp:1.0.0"
+  coreLibraryDesugaring libs.desugar.jdk.libs
 
   //noinspection GradleDependency
-  at_1_1Implementation "androidx.media3:media3-exoplayer:1.1.1"
+  at_1_0Implementation libs.bundles.media3.app.at10
   //noinspection GradleDependency
-  at_1_1Implementation "androidx.media3:media3-session:1.1.1"
+  at_1_1Implementation libs.bundles.media3.app.at11
   //noinspection GradleDependency
-  at_1_1Implementation "androidx.media3:media3-ui:1.1.1"
+  at_1_2Implementation libs.bundles.media3.app.at12
   //noinspection GradleDependency
-  at_1_1Implementation "androidx.media3:media3-exoplayer-ima:1.1.1"
+  at_1_3Implementation libs.bundles.media3.app.at13
   //noinspection GradleDependency
-  at_1_1Implementation "androidx.media3:media3-exoplayer-dash:1.1.1"
+  at_1_4Implementation libs.bundles.media3.app.at14
   //noinspection GradleDependency
-  at_1_1Implementation "androidx.media3:media3-exoplayer-hls:1.1.1"
+  at_1_5Implementation libs.bundles.media3.app.at15
   //noinspection GradleDependency
-  at_1_1Implementation "androidx.media3:media3-exoplayer-rtsp:1.1.1"
+  at_1_6Implementation libs.bundles.media3.app.at16
+  //noinspection GradleDependency
+  at_1_8Implementation libs.bundles.media3.app.at18
+  //noinspection GradleDependency
+  at_1_9Implementation libs.bundles.media3.app.at19
+  //noinspection GradleDependency
+  at_1_10Implementation libs.bundles.media3.app.at110
+  At_latestImplementation libs.bundles.media3.app.atLatest
 
-  //noinspection GradleDependency
-  at_1_2Implementation "androidx.media3:media3-exoplayer:1.2.0"
-  //noinspection GradleDependency
-  at_1_2Implementation "androidx.media3:media3-session:1.2.0"
-  //noinspection GradleDependency
-  at_1_2Implementation "androidx.media3:media3-ui:1.2.0"
-  //noinspection GradleDependency
-  at_1_2Implementation "androidx.media3:media3-exoplayer-ima:1.2.0"
-  //noinspection GradleDependency
-  at_1_2Implementation "androidx.media3:media3-exoplayer-dash:1.2.0"
-  //noinspection GradleDependency
-  at_1_2Implementation "androidx.media3:media3-exoplayer-hls:1.2.0"
-  //noinspection GradleDependency
-  at_1_2Implementation "androidx.media3:media3-exoplayer-rtsp:1.2.0"
-
-  //noinspection GradleDependency
-  at_1_3Implementation "androidx.media3:media3-exoplayer:1.3.0"
-  //noinspection GradleDependency
-  at_1_3Implementation "androidx.media3:media3-session:1.3.0"
-  //noinspection GradleDependency
-  at_1_3Implementation "androidx.media3:media3-ui:1.3.0"
-  //noinspection GradleDependency
-  at_1_3Implementation "androidx.media3:media3-exoplayer-ima:1.3.0"
-  //noinspection GradleDependency
-  at_1_3Implementation "androidx.media3:media3-exoplayer-dash:1.3.0"
-  //noinspection GradleDependency
-  at_1_3Implementation "androidx.media3:media3-exoplayer-hls:1.3.0"
-  //noinspection GradleDependency
-  at_1_3Implementation "androidx.media3:media3-exoplayer-rtsp:1.3.0"
-
-  //noinspection GradleDependency
-  at_1_4Implementation "androidx.media3:media3-exoplayer:1.4.1"
-  //noinspection GradleDependency
-  at_1_4Implementation "androidx.media3:media3-session:1.4.1"
-  //noinspection GradleDependency
-  at_1_4Implementation "androidx.media3:media3-ui:1.4.1"
-  //noinspection GradleDependency
-  at_1_4Implementation "androidx.media3:media3-exoplayer-ima:1.4.1"
-  //noinspection GradleDependency
-  at_1_4Implementation "androidx.media3:media3-exoplayer-dash:1.4.1"
-  //noinspection GradleDependency
-  at_1_4Implementation "androidx.media3:media3-exoplayer-hls:1.4.1"
-  //noinspection GradleDependency
-  at_1_4Implementation "androidx.media3:media3-exoplayer-rtsp:1.4.1"
-
-  //noinspection GradleDependency
-  at_1_5Implementation "androidx.media3:media3-exoplayer:1.5.0"
-  //noinspection GradleDependency
-  at_1_5Implementation "androidx.media3:media3-session:1.5.0"
-  //noinspection GradleDependency
-  at_1_5Implementation "androidx.media3:media3-ui:1.5.0"
-  //noinspection GradleDependency
-  at_1_5Implementation "androidx.media3:media3-exoplayer-ima:1.5.0"
-  //noinspection GradleDependency
-  at_1_5Implementation "androidx.media3:media3-exoplayer-dash:1.5.0"
-  //noinspection GradleDependency
-  at_1_5Implementation "androidx.media3:media3-exoplayer-hls:1.5.0"
-  //noinspection GradleDependency
-  at_1_5Implementation "androidx.media3:media3-exoplayer-rtsp:1.5.0"
-
-  //noinspection GradleDependency
-  at_1_6Implementation "androidx.media3:media3-exoplayer:1.6.0"
-  //noinspection GradleDependency
-  at_1_6Implementation "androidx.media3:media3-session:1.6.0"
-  //noinspection GradleDependency
-  at_1_6Implementation "androidx.media3:media3-ui:1.6.0"
-  //noinspection GradleDependency
-  at_1_6Implementation "androidx.media3:media3-exoplayer-ima:1.6.0"
-  //noinspection GradleDependency
-  at_1_6Implementation "androidx.media3:media3-exoplayer-dash:1.6.0"
-  //noinspection GradleDependency
-  at_1_6Implementation "androidx.media3:media3-exoplayer-hls:1.6.0"
-  //noinspection GradleDependency
-  at_1_6Implementation "androidx.media3:media3-exoplayer-rtsp:1.6.0"
-
-  //noinspection GradleDependency
-  at_1_8Implementation "androidx.media3:media3-exoplayer:1.8.0"
-  //noinspection GradleDependency
-  at_1_8Implementation "androidx.media3:media3-session:1.8.0"
-  //noinspection GradleDependency
-  at_1_8Implementation "androidx.media3:media3-ui:1.8.0"
-  //noinspection GradleDependency
-  at_1_8Implementation "androidx.media3:media3-exoplayer-ima:1.8.0"
-  //noinspection GradleDependency
-  at_1_8Implementation "androidx.media3:media3-exoplayer-dash:1.8.0"
-  //noinspection GradleDependency
-  at_1_8Implementation "androidx.media3:media3-exoplayer-hls:1.8.0"
-  //noinspection GradleDependency
-  at_1_8Implementation "androidx.media3:media3-exoplayer-rtsp:1.8.0"
-
-  //noinspection GradleDependency
-  at_1_9Implementation "androidx.media3:media3-exoplayer:1.9.0"
-  //noinspection GradleDependency
-  at_1_9Implementation "androidx.media3:media3-session:1.9.0"
-  //noinspection GradleDependency
-  at_1_9Implementation "androidx.media3:media3-ui:1.9.0"
-  //noinspection GradleDependency
-  at_1_9Implementation "androidx.media3:media3-exoplayer-ima:1.9.0"
-  //noinspection GradleDependency
-  at_1_9Implementation "androidx.media3:media3-exoplayer-dash:1.9.0"
-  //noinspection GradleDependency
-  at_1_9Implementation "androidx.media3:media3-exoplayer-hls:1.9.0"
-  //noinspection GradleDependency
-  at_1_9Implementation "androidx.media3:media3-exoplayer-rtsp:1.9.0"
-
-  //noinspection GradleDependency
-  at_1_10Implementation "androidx.media3:media3-exoplayer:1.10.0"
-  //noinspection GradleDependency
-  at_1_10Implementation "androidx.media3:media3-session:1.10.0"
-  //noinspection GradleDependency
-  at_1_10Implementation "androidx.media3:media3-ui:1.10.0"
-  //noinspection GradleDependency
-  at_1_10Implementation "androidx.media3:media3-exoplayer-ima:1.10.0"
-  //noinspection GradleDependency
-  at_1_10Implementation "androidx.media3:media3-exoplayer-dash:1.10.0"
-  //noinspection GradleDependency
-  at_1_10Implementation "androidx.media3:media3-exoplayer-hls:1.10.0"
-  //noinspection GradleDependency
-  at_1_10Implementation "androidx.media3:media3-exoplayer-rtsp:1.10.0"
-
-  At_latestImplementation "androidx.media3:media3-exoplayer:1.10.0"
-  At_latestImplementation "androidx.media3:media3-session:1.10.0"
-  At_latestImplementation "androidx.media3:media3-ui:1.10.0"
-  At_latestImplementation "androidx.media3:media3-exoplayer-ima:1.10.0"
-  At_latestImplementation "androidx.media3:media3-exoplayer-dash:1.10.0"
-  At_latestImplementation "androidx.media3:media3-exoplayer-hls:1.10.0"
-  At_latestImplementation "androidx.media3:media3-exoplayer-rtsp:1.10.0"
-
-  androidTestImplementation 'androidx.test:runner:1.7.0'
-  androidTestImplementation 'androidx.test:rules:1.7.0'
+  androidTestImplementation libs.androidx.test.runner
+  androidTestImplementation libs.androidx.test.rules
   // Optional -- Hamcrest library
-  androidTestImplementation 'org.hamcrest:hamcrest-library:3.0'
+  androidTestImplementation libs.hamcrest.library
   // Optional -- UI testing with Espresso
-  androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
+  androidTestImplementation libs.androidx.test.espresso.core
   // Optional -- UI testing with UI Automator
-  androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.3.0'
-  androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+  androidTestImplementation libs.androidx.test.uiautomator
+  androidTestImplementation libs.androidx.test.junit
 
-  api 'org.checkerframework:checker-qual:3.49.5'
+  api libs.checker.qual
 
   // Automated tests should always test the local module and not the maven dependency.
   implementation project(":library")

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,14 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
 plugins {
-  id 'com.android.application' version '8.13.2' apply false
-  id 'com.android.library' version '8.13.2' apply false
-  id 'org.jetbrains.kotlin.android' version '2.2.10' apply false
-  id "org.jetbrains.kotlin.plugin.compose" version "2.2.10"
-  id 'com.mux.gradle.android.mux-android-distribution' version '1.3.0' apply false
-  id "org.jetbrains.dokka" version "1.6.10"
+  alias(libs.plugins.android.application) apply false
+  alias(libs.plugins.android.library) apply false
+  alias(libs.plugins.kotlin.android) apply false
+  alias(libs.plugins.kotlin.compose)
+  alias(libs.plugins.mux.android.distribution) apply false
+  alias(libs.plugins.dokka)
 }
 
 allprojects {
-  project.ext {
-    androidCoreVersion = '1.7.2'
-    javaCoreVersion = '8.9.2'
-  }
-
   tasks.withType(DokkaTaskPartial.class) {
     dokkaSourceSets.configureEach {
       //includes.from("README.md")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,324 @@
+[versions]
+# Plugins
+agp = "8.13.2"
+kotlin = "2.2.10"
+muxAndroidDistribution = "1.3.0"
+dokka = "1.6.10"
+
+# Mux core deps
+muxCoreAndroid = "1.7.2"
+muxCoreJava = "8.9.2"
+
+# media3 per-variant pins.
+#
+# Naming: `at<MAJOR><MINOR>` = the matching `at_<MAJOR>_<MINOR>` Android flavor.
+# (We can't use dashes or underscores here because version-catalog accessor
+# segments can't start with a digit — `at-1-0` becomes the unusable `at.1.0`.)
+#
+# `at_1_1` and `at_1_4` each have two refs:
+#   * the bare `atNN` is the .0 patch used by :library and :library-exo so
+#     downstream consumers benefit from optimistic version matching.
+#   * `atNNapp` is the patch we actually build and test against in :app,
+#     :automatedtests, and (for at_1_1 only) :library-ima.
+media3-at10 = "1.0.0"
+media3-at11 = "1.1.0"
+media3-at11app = "1.1.1"
+media3-at12 = "1.2.0"
+media3-at13 = "1.3.0"
+media3-at14 = "1.4.0"
+media3-at14app = "1.4.1"
+media3-at15 = "1.5.0"
+media3-at16 = "1.6.0"
+media3-at18 = "1.8.0"
+media3-at19 = "1.9.0"
+media3-at110 = "1.10.0"
+media3-atLatest = "1.10.0"
+
+# AndroidX / Compose / Material
+androidx-coreKtx = "1.17.0"
+androidx-appcompat = "1.7.1"
+androidx-constraintlayout = "2.2.1"
+androidx-lifecycleRuntimeKtx = "2.9.2"
+androidx-activityCompose = "1.10.1"
+androidx-composeBom = "2025.08.00"
+androidx-navigation = "2.9.3"
+material = "1.12.0"
+
+# Misc
+kotlinxCoroutines = "1.10.2"
+desugarJdkLibs = "2.1.5"
+checkerQual = "3.49.5"
+kotlinComposeCompilerExt = "1.5.14"
+
+# Testing
+junit = "4.13.2"
+androidx-testJunit = "1.3.0"
+androidx-testEspresso = "3.7.0"
+androidx-testRunner = "1.7.0"
+androidx-testRules = "1.7.0"
+androidx-testUiautomator = "2.3.0"
+hamcrest = "3.0"
+mockk = "1.14.5"
+robolectric = "4.15.1"
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+android-library = { id = "com.android.library", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+mux-android-distribution = { id = "com.mux.gradle.android.mux-android-distribution", version.ref = "muxAndroidDistribution" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+
+[libraries]
+# --- Mux core ---
+mux-core-android = { group = "com.mux.stats.sdk.muxstats", name = "android", version.ref = "muxCoreAndroid" }
+mux-core-java = { group = "com.mux", name = "stats.muxcore", version.ref = "muxCoreJava" }
+
+# --- media3-common (only :library) ---
+media3-common-at10 = { group = "androidx.media3", name = "media3-common", version.ref = "media3-at10" }
+media3-common-at11 = { group = "androidx.media3", name = "media3-common", version.ref = "media3-at11" }
+media3-common-at12 = { group = "androidx.media3", name = "media3-common", version.ref = "media3-at12" }
+media3-common-at13 = { group = "androidx.media3", name = "media3-common", version.ref = "media3-at13" }
+media3-common-at14 = { group = "androidx.media3", name = "media3-common", version.ref = "media3-at14" }
+media3-common-at15 = { group = "androidx.media3", name = "media3-common", version.ref = "media3-at15" }
+media3-common-at16 = { group = "androidx.media3", name = "media3-common", version.ref = "media3-at16" }
+media3-common-at18 = { group = "androidx.media3", name = "media3-common", version.ref = "media3-at18" }
+media3-common-at19 = { group = "androidx.media3", name = "media3-common", version.ref = "media3-at19" }
+media3-common-at110 = { group = "androidx.media3", name = "media3-common", version.ref = "media3-at110" }
+media3-common-atLatest = { group = "androidx.media3", name = "media3-common", version.ref = "media3-atLatest" }
+
+# --- media3-exoplayer (:library-exo uses bare alias; :library-ima at_1_1 + :app + :automatedtests use `app` variants) ---
+media3-exoplayer-at10 = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3-at10" }
+media3-exoplayer-at11 = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3-at11" }
+media3-exoplayer-at11app = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3-at11app" }
+media3-exoplayer-at12 = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3-at12" }
+media3-exoplayer-at13 = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3-at13" }
+media3-exoplayer-at14 = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3-at14" }
+media3-exoplayer-at14app = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3-at14app" }
+media3-exoplayer-at15 = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3-at15" }
+media3-exoplayer-at16 = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3-at16" }
+media3-exoplayer-at18 = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3-at18" }
+media3-exoplayer-at19 = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3-at19" }
+media3-exoplayer-at110 = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3-at110" }
+media3-exoplayer-atLatest = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3-atLatest" }
+
+# --- media3-exoplayer-hls (:library-exo bare; :app + :automatedtests use `app` variants) ---
+media3-exoplayerHls-at10 = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3-at10" }
+media3-exoplayerHls-at11 = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3-at11" }
+media3-exoplayerHls-at11app = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3-at11app" }
+media3-exoplayerHls-at12 = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3-at12" }
+media3-exoplayerHls-at13 = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3-at13" }
+media3-exoplayerHls-at14 = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3-at14" }
+media3-exoplayerHls-at14app = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3-at14app" }
+media3-exoplayerHls-at15 = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3-at15" }
+media3-exoplayerHls-at16 = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3-at16" }
+media3-exoplayerHls-at18 = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3-at18" }
+media3-exoplayerHls-at19 = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3-at19" }
+media3-exoplayerHls-at110 = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3-at110" }
+media3-exoplayerHls-atLatest = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3-atLatest" }
+
+# --- media3-exoplayer-ima (:library-ima bare for at_1_4, `app` for at_1_1; :app + :automatedtests `app`) ---
+media3-exoplayerIma-at10 = { group = "androidx.media3", name = "media3-exoplayer-ima", version.ref = "media3-at10" }
+media3-exoplayerIma-at11app = { group = "androidx.media3", name = "media3-exoplayer-ima", version.ref = "media3-at11app" }
+media3-exoplayerIma-at12 = { group = "androidx.media3", name = "media3-exoplayer-ima", version.ref = "media3-at12" }
+media3-exoplayerIma-at13 = { group = "androidx.media3", name = "media3-exoplayer-ima", version.ref = "media3-at13" }
+media3-exoplayerIma-at14 = { group = "androidx.media3", name = "media3-exoplayer-ima", version.ref = "media3-at14" }
+media3-exoplayerIma-at14app = { group = "androidx.media3", name = "media3-exoplayer-ima", version.ref = "media3-at14app" }
+media3-exoplayerIma-at15 = { group = "androidx.media3", name = "media3-exoplayer-ima", version.ref = "media3-at15" }
+media3-exoplayerIma-at16 = { group = "androidx.media3", name = "media3-exoplayer-ima", version.ref = "media3-at16" }
+media3-exoplayerIma-at18 = { group = "androidx.media3", name = "media3-exoplayer-ima", version.ref = "media3-at18" }
+media3-exoplayerIma-at19 = { group = "androidx.media3", name = "media3-exoplayer-ima", version.ref = "media3-at19" }
+media3-exoplayerIma-at110 = { group = "androidx.media3", name = "media3-exoplayer-ima", version.ref = "media3-at110" }
+media3-exoplayerIma-atLatest = { group = "androidx.media3", name = "media3-exoplayer-ima", version.ref = "media3-atLatest" }
+
+# --- media3-exoplayer-dash (:app + :automatedtests; always the `app` patch where applicable) ---
+media3-exoplayerDash-at10 = { group = "androidx.media3", name = "media3-exoplayer-dash", version.ref = "media3-at10" }
+media3-exoplayerDash-at11app = { group = "androidx.media3", name = "media3-exoplayer-dash", version.ref = "media3-at11app" }
+media3-exoplayerDash-at12 = { group = "androidx.media3", name = "media3-exoplayer-dash", version.ref = "media3-at12" }
+media3-exoplayerDash-at13 = { group = "androidx.media3", name = "media3-exoplayer-dash", version.ref = "media3-at13" }
+media3-exoplayerDash-at14app = { group = "androidx.media3", name = "media3-exoplayer-dash", version.ref = "media3-at14app" }
+media3-exoplayerDash-at15 = { group = "androidx.media3", name = "media3-exoplayer-dash", version.ref = "media3-at15" }
+media3-exoplayerDash-at16 = { group = "androidx.media3", name = "media3-exoplayer-dash", version.ref = "media3-at16" }
+media3-exoplayerDash-at18 = { group = "androidx.media3", name = "media3-exoplayer-dash", version.ref = "media3-at18" }
+media3-exoplayerDash-at19 = { group = "androidx.media3", name = "media3-exoplayer-dash", version.ref = "media3-at19" }
+media3-exoplayerDash-at110 = { group = "androidx.media3", name = "media3-exoplayer-dash", version.ref = "media3-at110" }
+media3-exoplayerDash-atLatest = { group = "androidx.media3", name = "media3-exoplayer-dash", version.ref = "media3-atLatest" }
+
+# --- media3-exoplayer-rtsp (:app + :automatedtests; always the `app` patch where applicable) ---
+media3-exoplayerRtsp-at10 = { group = "androidx.media3", name = "media3-exoplayer-rtsp", version.ref = "media3-at10" }
+media3-exoplayerRtsp-at11app = { group = "androidx.media3", name = "media3-exoplayer-rtsp", version.ref = "media3-at11app" }
+media3-exoplayerRtsp-at12 = { group = "androidx.media3", name = "media3-exoplayer-rtsp", version.ref = "media3-at12" }
+media3-exoplayerRtsp-at13 = { group = "androidx.media3", name = "media3-exoplayer-rtsp", version.ref = "media3-at13" }
+media3-exoplayerRtsp-at14app = { group = "androidx.media3", name = "media3-exoplayer-rtsp", version.ref = "media3-at14app" }
+media3-exoplayerRtsp-at15 = { group = "androidx.media3", name = "media3-exoplayer-rtsp", version.ref = "media3-at15" }
+media3-exoplayerRtsp-at16 = { group = "androidx.media3", name = "media3-exoplayer-rtsp", version.ref = "media3-at16" }
+media3-exoplayerRtsp-at18 = { group = "androidx.media3", name = "media3-exoplayer-rtsp", version.ref = "media3-at18" }
+media3-exoplayerRtsp-at19 = { group = "androidx.media3", name = "media3-exoplayer-rtsp", version.ref = "media3-at19" }
+media3-exoplayerRtsp-at110 = { group = "androidx.media3", name = "media3-exoplayer-rtsp", version.ref = "media3-at110" }
+media3-exoplayerRtsp-atLatest = { group = "androidx.media3", name = "media3-exoplayer-rtsp", version.ref = "media3-atLatest" }
+
+# --- media3-session (:app + :automatedtests; always the `app` patch where applicable) ---
+media3-session-at10 = { group = "androidx.media3", name = "media3-session", version.ref = "media3-at10" }
+media3-session-at11app = { group = "androidx.media3", name = "media3-session", version.ref = "media3-at11app" }
+media3-session-at12 = { group = "androidx.media3", name = "media3-session", version.ref = "media3-at12" }
+media3-session-at13 = { group = "androidx.media3", name = "media3-session", version.ref = "media3-at13" }
+media3-session-at14app = { group = "androidx.media3", name = "media3-session", version.ref = "media3-at14app" }
+media3-session-at15 = { group = "androidx.media3", name = "media3-session", version.ref = "media3-at15" }
+media3-session-at16 = { group = "androidx.media3", name = "media3-session", version.ref = "media3-at16" }
+media3-session-at18 = { group = "androidx.media3", name = "media3-session", version.ref = "media3-at18" }
+media3-session-at19 = { group = "androidx.media3", name = "media3-session", version.ref = "media3-at19" }
+media3-session-at110 = { group = "androidx.media3", name = "media3-session", version.ref = "media3-at110" }
+media3-session-atLatest = { group = "androidx.media3", name = "media3-session", version.ref = "media3-atLatest" }
+
+# --- media3-ui (:app + :automatedtests; always the `app` patch where applicable) ---
+media3-ui-at10 = { group = "androidx.media3", name = "media3-ui", version.ref = "media3-at10" }
+media3-ui-at11app = { group = "androidx.media3", name = "media3-ui", version.ref = "media3-at11app" }
+media3-ui-at12 = { group = "androidx.media3", name = "media3-ui", version.ref = "media3-at12" }
+media3-ui-at13 = { group = "androidx.media3", name = "media3-ui", version.ref = "media3-at13" }
+media3-ui-at14app = { group = "androidx.media3", name = "media3-ui", version.ref = "media3-at14app" }
+media3-ui-at15 = { group = "androidx.media3", name = "media3-ui", version.ref = "media3-at15" }
+media3-ui-at16 = { group = "androidx.media3", name = "media3-ui", version.ref = "media3-at16" }
+media3-ui-at18 = { group = "androidx.media3", name = "media3-ui", version.ref = "media3-at18" }
+media3-ui-at19 = { group = "androidx.media3", name = "media3-ui", version.ref = "media3-at19" }
+media3-ui-at110 = { group = "androidx.media3", name = "media3-ui", version.ref = "media3-at110" }
+media3-ui-atLatest = { group = "androidx.media3", name = "media3-ui", version.ref = "media3-atLatest" }
+
+# --- AndroidX, Material, Compose ---
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidx-coreKtx" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidx-appcompat" }
+androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "androidx-constraintlayout" }
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidx-lifecycleRuntimeKtx" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidx-activityCompose" }
+androidx-navigation-fragment = { group = "androidx.navigation", name = "navigation-fragment", version.ref = "androidx-navigation" }
+androidx-navigation-ui = { group = "androidx.navigation", name = "navigation-ui", version.ref = "androidx-navigation" }
+material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+
+# Compose (versions from the BOM)
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidx-composeBom" }
+androidx-compose-ui = { module = "androidx.compose.ui:ui" }
+androidx-compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
+androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
+androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
+androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
+androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
+
+# --- Misc ---
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
+desugar-jdk-libs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugarJdkLibs" }
+checker-qual = { group = "org.checkerframework", name = "checker-qual", version.ref = "checkerQual" }
+
+# --- Testing ---
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+androidx-test-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-testJunit" }
+androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidx-testEspresso" }
+androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidx-testRunner" }
+androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "androidx-testRules" }
+androidx-test-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "androidx-testUiautomator" }
+hamcrest-library = { group = "org.hamcrest", name = "hamcrest-library", version.ref = "hamcrest" }
+mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
+
+[bundles]
+# media3 deps for :app and :automatedtests, per variant. Each variant pulls in
+# 7 sibling artifacts (exoplayer, session, ui, exoplayer-ima, exoplayer-dash,
+# exoplayer-hls, exoplayer-rtsp) at the patch we test against.
+media3-app-at10 = [
+  "media3-exoplayer-at10",
+  "media3-session-at10",
+  "media3-ui-at10",
+  "media3-exoplayerIma-at10",
+  "media3-exoplayerDash-at10",
+  "media3-exoplayerHls-at10",
+  "media3-exoplayerRtsp-at10",
+]
+media3-app-at11 = [
+  "media3-exoplayer-at11app",
+  "media3-session-at11app",
+  "media3-ui-at11app",
+  "media3-exoplayerIma-at11app",
+  "media3-exoplayerDash-at11app",
+  "media3-exoplayerHls-at11app",
+  "media3-exoplayerRtsp-at11app",
+]
+media3-app-at12 = [
+  "media3-exoplayer-at12",
+  "media3-session-at12",
+  "media3-ui-at12",
+  "media3-exoplayerIma-at12",
+  "media3-exoplayerDash-at12",
+  "media3-exoplayerHls-at12",
+  "media3-exoplayerRtsp-at12",
+]
+media3-app-at13 = [
+  "media3-exoplayer-at13",
+  "media3-session-at13",
+  "media3-ui-at13",
+  "media3-exoplayerIma-at13",
+  "media3-exoplayerDash-at13",
+  "media3-exoplayerHls-at13",
+  "media3-exoplayerRtsp-at13",
+]
+media3-app-at14 = [
+  "media3-exoplayer-at14app",
+  "media3-session-at14app",
+  "media3-ui-at14app",
+  "media3-exoplayerIma-at14app",
+  "media3-exoplayerDash-at14app",
+  "media3-exoplayerHls-at14app",
+  "media3-exoplayerRtsp-at14app",
+]
+media3-app-at15 = [
+  "media3-exoplayer-at15",
+  "media3-session-at15",
+  "media3-ui-at15",
+  "media3-exoplayerIma-at15",
+  "media3-exoplayerDash-at15",
+  "media3-exoplayerHls-at15",
+  "media3-exoplayerRtsp-at15",
+]
+media3-app-at16 = [
+  "media3-exoplayer-at16",
+  "media3-session-at16",
+  "media3-ui-at16",
+  "media3-exoplayerIma-at16",
+  "media3-exoplayerDash-at16",
+  "media3-exoplayerHls-at16",
+  "media3-exoplayerRtsp-at16",
+]
+media3-app-at18 = [
+  "media3-exoplayer-at18",
+  "media3-session-at18",
+  "media3-ui-at18",
+  "media3-exoplayerIma-at18",
+  "media3-exoplayerDash-at18",
+  "media3-exoplayerHls-at18",
+  "media3-exoplayerRtsp-at18",
+]
+media3-app-at19 = [
+  "media3-exoplayer-at19",
+  "media3-session-at19",
+  "media3-ui-at19",
+  "media3-exoplayerIma-at19",
+  "media3-exoplayerDash-at19",
+  "media3-exoplayerHls-at19",
+  "media3-exoplayerRtsp-at19",
+]
+media3-app-at110 = [
+  "media3-exoplayer-at110",
+  "media3-session-at110",
+  "media3-ui-at110",
+  "media3-exoplayerIma-at110",
+  "media3-exoplayerDash-at110",
+  "media3-exoplayerHls-at110",
+  "media3-exoplayerRtsp-at110",
+]
+media3-app-atLatest = [
+  "media3-exoplayer-atLatest",
+  "media3-session-atLatest",
+  "media3-ui-atLatest",
+  "media3-exoplayerIma-atLatest",
+  "media3-exoplayerDash-atLatest",
+  "media3-exoplayerHls-atLatest",
+  "media3-exoplayerRtsp-atLatest",
+]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ dokka = "1.6.10"
 
 # Mux core deps
 muxCoreAndroid = "1.7.2"
-muxCoreJava = "8.9.2"
+muxCoreJava = "8.10.0"
 
 # media3 per-variant pins.
 #

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-  id 'com.android.library'
-  id 'org.jetbrains.kotlin.android'
-  id 'com.mux.gradle.android.mux-android-distribution'
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.kotlin.android)
+  alias(libs.plugins.mux.android.distribution)
 }
 
 android {
@@ -133,63 +133,63 @@ dependencies {
   debugImplementation project(':library')
 
   //noinspection GradleDependency
-  at_1_0Api "androidx.media3:media3-exoplayer:1.0.0"
+  at_1_0Api libs.media3.exoplayer.at10
   //noinspection GradleDependency
-  at_1_0CompileOnly "androidx.media3:media3-exoplayer-hls:1.0.0"
+  at_1_0CompileOnly libs.media3.exoplayerHls.at10
 
   //noinspection GradleDependency
-  at_1_1Api "androidx.media3:media3-exoplayer:1.1.0"
+  at_1_1Api libs.media3.exoplayer.at11
   //noinspection GradleDependency
-  at_1_1CompileOnly "androidx.media3:media3-exoplayer-hls:1.1.0"
+  at_1_1CompileOnly libs.media3.exoplayerHls.at11
 
   //noinspection GradleDependency
-  at_1_2Api "androidx.media3:media3-exoplayer:1.2.0"
+  at_1_2Api libs.media3.exoplayer.at12
   //noinspection GradleDependency
-  at_1_2CompileOnly "androidx.media3:media3-exoplayer-hls:1.2.0"
+  at_1_2CompileOnly libs.media3.exoplayerHls.at12
 
   //noinspection GradleDependency
-  at_1_3Api "androidx.media3:media3-exoplayer:1.3.0"
+  at_1_3Api libs.media3.exoplayer.at13
   //noinspection GradleDependency
-  at_1_3CompileOnly "androidx.media3:media3-exoplayer-hls:1.3.0"
+  at_1_3CompileOnly libs.media3.exoplayerHls.at13
 
   //noinspection GradleDependency
-  at_1_4Api "androidx.media3:media3-exoplayer:1.4.0"
+  at_1_4Api libs.media3.exoplayer.at14
   //noinspection GradleDependency
-  at_1_4CompileOnly "androidx.media3:media3-exoplayer-hls:1.4.0"
+  at_1_4CompileOnly libs.media3.exoplayerHls.at14
 
   //noinspection GradleDependency
-  at_1_5Api "androidx.media3:media3-exoplayer:1.5.0"
+  at_1_5Api libs.media3.exoplayer.at15
   //noinspection GradleDependency
-  at_1_5CompileOnly "androidx.media3:media3-exoplayer-hls:1.5.0"
+  at_1_5CompileOnly libs.media3.exoplayerHls.at15
 
   //noinspection GradleDependency
-  at_1_6Api "androidx.media3:media3-exoplayer:1.6.0"
+  at_1_6Api libs.media3.exoplayer.at16
   //noinspection GradleDependency
-  at_1_6CompileOnly "androidx.media3:media3-exoplayer-hls:1.6.0"
+  at_1_6CompileOnly libs.media3.exoplayerHls.at16
 
   //noinspection GradleDependency
-  at_1_8Api "androidx.media3:media3-exoplayer:1.8.0"
+  at_1_8Api libs.media3.exoplayer.at18
   //noinspection GradleDependency
-  at_1_8CompileOnly "androidx.media3:media3-exoplayer-hls:1.8.0"
+  at_1_8CompileOnly libs.media3.exoplayerHls.at18
 
   //noinspection GradleDependency
-  at_1_9Api "androidx.media3:media3-exoplayer:1.9.0"
+  at_1_9Api libs.media3.exoplayer.at19
   //noinspection GradleDependency
-  at_1_9CompileOnly "androidx.media3:media3-exoplayer-hls:1.9.0"
+  at_1_9CompileOnly libs.media3.exoplayerHls.at19
 
   //noinspection GradleDependency
-  at_1_10Api "androidx.media3:media3-exoplayer:1.10.0"
+  at_1_10Api libs.media3.exoplayer.at110
   //noinspection GradleDependency
-  at_1_10CompileOnly "androidx.media3:media3-exoplayer-hls:1.10.0"
+  at_1_10CompileOnly libs.media3.exoplayerHls.at110
 
   //noinspection GradleDependency
-  At_latestApi "androidx.media3:media3-exoplayer:1.10.0"
+  At_latestApi libs.media3.exoplayer.atLatest
   //noinspection GradleDependency
-  At_latestCompileOnly "androidx.media3:media3-exoplayer-hls:1.10.0"
+  At_latestCompileOnly libs.media3.exoplayerHls.atLatest
 
-  testImplementation 'junit:junit:4.13.2'
-  androidTestImplementation 'androidx.test.ext:junit:1.3.0'
-  androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
+  testImplementation libs.junit
+  androidTestImplementation libs.androidx.test.junit
+  androidTestImplementation libs.androidx.test.espresso.core
 }
 
 afterEvaluate {
@@ -210,4 +210,3 @@ afterEvaluate {
             project.dependencies.add(sourceSet.apiConfigurationName, depNotation)
           }
 }
-

--- a/library-exo/build.gradle
+++ b/library-exo/build.gradle
@@ -188,6 +188,7 @@ dependencies {
   At_latestCompileOnly libs.media3.exoplayerHls.atLatest
 
   testImplementation libs.junit
+  testImplementation libs.robolectric
   androidTestImplementation libs.androidx.test.junit
   androidTestImplementation libs.androidx.test.espresso.core
 }

--- a/library-ima/build.gradle
+++ b/library-ima/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-  id 'com.android.library'
-  id 'org.jetbrains.kotlin.android'
-  id 'com.mux.gradle.android.mux-android-distribution'
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.kotlin.android)
+  alias(libs.plugins.mux.android.distribution)
 }
 
 android {
@@ -169,63 +169,63 @@ muxDistribution {
 dependencies {
   debugImplementation project(':library')
 
-  coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
+  coreLibraryDesugaring libs.desugar.jdk.libs
 
   //noinspection GradleDependency
-  at_1_0Api "androidx.media3:media3-exoplayer-ima:1.0.0"
+  at_1_0Api libs.media3.exoplayerIma.at10
   //noinspection GradleDependency
-  at_1_0Api "androidx.media3:media3-exoplayer:1.0.0"
+  at_1_0Api libs.media3.exoplayer.at10
   //noinspection GradleDependency
-  at_1_1Api "androidx.media3:media3-exoplayer-ima:1.1.1"
+  at_1_1Api libs.media3.exoplayerIma.at11app
   //noinspection GradleDependency
-  at_1_1Api "androidx.media3:media3-exoplayer:1.1.1"
+  at_1_1Api libs.media3.exoplayer.at11app
   //noinspection GradleDependency
-  at_1_2Api "androidx.media3:media3-exoplayer-ima:1.2.0"
+  at_1_2Api libs.media3.exoplayerIma.at12
   //noinspection GradleDependency
-  at_1_2Api "androidx.media3:media3-exoplayer:1.2.0"
+  at_1_2Api libs.media3.exoplayer.at12
   //noinspection GradleDependency
-  at_1_3Api "androidx.media3:media3-exoplayer-ima:1.3.0"
+  at_1_3Api libs.media3.exoplayerIma.at13
   //noinspection GradleDependency
-  at_1_3Api "androidx.media3:media3-exoplayer:1.3.0"
+  at_1_3Api libs.media3.exoplayer.at13
   //noinspection GradleDependency
-  at_1_4Api "androidx.media3:media3-exoplayer-ima:1.4.0"
+  at_1_4Api libs.media3.exoplayerIma.at14
   //noinspection GradleDependency
-  at_1_4Api "androidx.media3:media3-exoplayer:1.4.0"
+  at_1_4Api libs.media3.exoplayer.at14
   //noinspection GradleDependency
-  at_1_5Api "androidx.media3:media3-exoplayer-ima:1.5.0"
+  at_1_5Api libs.media3.exoplayerIma.at15
   //noinspection GradleDependency
-  at_1_5Api "androidx.media3:media3-exoplayer:1.5.0"
+  at_1_5Api libs.media3.exoplayer.at15
   //noinspection GradleDependency
-  at_1_6Api "androidx.media3:media3-exoplayer:1.6.0"
+  at_1_6Api libs.media3.exoplayer.at16
   //noinspection GradleDependency
-  at_1_6Api "androidx.media3:media3-exoplayer-ima:1.6.0"
+  at_1_6Api libs.media3.exoplayerIma.at16
   //noinspection GradleDependency
-  at_1_8Api "androidx.media3:media3-exoplayer:1.8.0"
+  at_1_8Api libs.media3.exoplayer.at18
   //noinspection GradleDependency
-  at_1_8Api "androidx.media3:media3-exoplayer-ima:1.8.0"
+  at_1_8Api libs.media3.exoplayerIma.at18
   //noinspection GradleDependency
-  at_1_9Api "androidx.media3:media3-exoplayer:1.9.0"
+  at_1_9Api libs.media3.exoplayer.at19
   //noinspection GradleDependency
-  at_1_9Api "androidx.media3:media3-exoplayer-ima:1.9.0"
+  at_1_9Api libs.media3.exoplayerIma.at19
   //noinspection GradleDependency
-  at_1_10Api "androidx.media3:media3-exoplayer:1.10.0"
+  at_1_10Api libs.media3.exoplayer.at110
   //noinspection GradleDependency
-  at_1_10Api "androidx.media3:media3-exoplayer-ima:1.10.0"
+  at_1_10Api libs.media3.exoplayerIma.at110
 
   //noinspection GradleDependency
-  At_latestApi "androidx.media3:media3-exoplayer:1.10.0"
+  At_latestApi libs.media3.exoplayer.atLatest
   //noinspection GradleDependency
-  At_latestApi "androidx.media3:media3-exoplayer-ima:1.10.0"
+  At_latestApi libs.media3.exoplayerIma.atLatest
 
-  implementation 'androidx.core:core-ktx:1.17.0'
+  implementation libs.androidx.core.ktx
 
-  testImplementation 'junit:junit:4.13.2'
-  testImplementation 'androidx.test.ext:junit:1.3.0'
-  testImplementation "io.mockk:mockk:1.14.5"
-  testImplementation 'org.robolectric:robolectric:4.15.1'
+  testImplementation libs.junit
+  testImplementation libs.androidx.test.junit
+  testImplementation libs.mockk
+  testImplementation libs.robolectric
 
-  androidTestImplementation 'androidx.test.ext:junit:1.3.0'
-  androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
+  androidTestImplementation libs.androidx.test.junit
+  androidTestImplementation libs.androidx.test.espresso.core
 }
 
 afterEvaluate {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-  id 'com.android.library'
-  id 'org.jetbrains.kotlin.android'
-  id 'com.mux.gradle.android.mux-android-distribution'
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.kotlin.android)
+  alias(libs.plugins.mux.android.distribution)
 }
 
 android {
@@ -129,39 +129,39 @@ muxDistribution {
 }
 
 dependencies {
-  api "com.mux.stats.sdk.muxstats:android:${androidCoreVersion}"
-  api "com.mux:stats.muxcore:${javaCoreVersion}"
+  api libs.mux.core.android
+  api libs.mux.core.java
 
   //noinspection GradleDependency
-  at_1_0Api "androidx.media3:media3-common:1.0.0"
+  at_1_0Api libs.media3.common.at10
   //noinspection GradleDependency
-  at_1_1Api "androidx.media3:media3-common:1.1.0"
+  at_1_1Api libs.media3.common.at11
   //noinspection GradleDependency
-  at_1_2Api "androidx.media3:media3-common:1.2.0"
+  at_1_2Api libs.media3.common.at12
   //noinspection GradleDependency
-  at_1_3Api "androidx.media3:media3-common:1.3.0"
+  at_1_3Api libs.media3.common.at13
   //noinspection GradleDependency // benefit from optimistic matching
-  at_1_4Api "androidx.media3:media3-common:1.4.0"
+  at_1_4Api libs.media3.common.at14
   //noinspection GradleDependency // benefit from optimistic matching
-  at_1_5Api "androidx.media3:media3-common:1.5.0"
+  at_1_5Api libs.media3.common.at15
   //noinspection GradleDependency // benefit from optimistic matching
-  at_1_6Api "androidx.media3:media3-common:1.6.0"
+  at_1_6Api libs.media3.common.at16
   //noinspection GradleDependency // benefit from optimistic matching
-  at_1_8Api "androidx.media3:media3-common:1.8.0"
+  at_1_8Api libs.media3.common.at18
   //noinspection GradleDependency // benefit from optimistic matching
-  at_1_9Api "androidx.media3:media3-common:1.9.0"
+  at_1_9Api libs.media3.common.at19
   //noinspection GradleDependency // benefit from optimistic matching
-  at_1_10Api "androidx.media3:media3-common:1.10.0"
+  at_1_10Api libs.media3.common.at110
   //noinspection GradleDependency // benefit from optimistic matching
-  At_latestApi "androidx.media3:media3-common:1.10.0"
+  At_latestApi libs.media3.common.atLatest
 
-  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2"
+  implementation libs.kotlinx.coroutines.android
 
-  testImplementation 'junit:junit:4.13.2'
-  testImplementation 'androidx.test.ext:junit:1.3.0'
-  testImplementation "io.mockk:mockk:1.14.5"
-  testImplementation 'org.robolectric:robolectric:4.15.1'
+  testImplementation libs.junit
+  testImplementation libs.androidx.test.junit
+  testImplementation libs.mockk
+  testImplementation libs.robolectric
 
-  androidTestImplementation 'androidx.test.ext:junit:1.3.0'
-  androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
+  androidTestImplementation libs.androidx.test.junit
+  androidTestImplementation libs.androidx.test.espresso.core
 }


### PR DESCRIPTION
Instead of declaring dependency names and versions in each build file, we have a single toml that each build file can reference. This prevents version conflicts between ~~versions~~ modules and has been the "standard" way to handle deps with gradle for a long while

It's not breaking anything, there's no ticking clock forcing us to update, but I was able to do it in parallel with my other work so here it is

[More info](https://docs.gradle.org/current/userguide/version_catalogs.html)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only Gradle wiring with versions preserved in the catalog; risk is mainly a mis-typed catalog alias breaking a flavor build until CI catches it.
> 
> **Overview**
> Introduces **`gradle/libs.versions.toml`** as the single source of truth for plugin versions, library coordinates, and Media3 pins across the multi-flavor build.
> 
> **Root and module `build.gradle` files** switch from inline `id '…' version '…'` / string Maven coordinates to **`alias(libs.plugins.*)`** and **`libs.*`** accessors. The root **`allprojects { project.ext { androidCoreVersion / javaCoreVersion } }`** block is removed in favor of catalog entries for Mux core artifacts.
> 
> **`:app` and `:automatedtests`** replace long per-flavor lists of seven Media3 artifacts with **`libs.bundles.media3.app.at*`** bundles. **`:library`**, **`:library-exo`**, and **`:library-ima`** use catalog libraries per flavor; the TOML documents the existing split between **`.0` patch** refs for published library modules vs **`app` patch** refs where sample/test apps (and some IMA pins) compile against specific Media3 versions.
> 
> **`:app`** also wires the Compose compiler extension version through **`libs.versions.kotlinComposeCompilerExt`**. Intended behavior is unchanged; maintenance and version alignment are centralized in the catalog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9093fcc06516e36bda99bb4764ed767733f0680d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->