### PR TITLE
Audio track changes

### DIFF
--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/Constants.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/Constants.kt
@@ -6,6 +6,7 @@ object Constants {
   const val VOD_TEST_URL_TEARS_OF_STEEL = "https://stream.mux.com/u02xH9SB1ZZNNjPiQp4l6mhzBKJ101uExYx4LU02J5Xm88.m3u8"
   const val VOD_TEST_URL_BIG_BUCK_BUNNY = "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8"
   const val VOD_TEST_SHORT_VIDEO = "https://stream.mux.com/a4nOgmxGWg6gULfcBbAa00gXyfcwPnAFldF8RdsNyk8M.m3u8"
+  const val VOD_TEST_ELEPHANTS_DREAM_DASH = "https://rdmedia.bbc.co.uk/elephants_dream/1/client_manifest-all.mpd"
   const val AD_TAG_SIMPLE_W_MID_ROLL = "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/vmap_ad_samples&sz=640x480&cust_params=sample_ar%3Dpremidpostoptimizedpod&ciu_szs=300x250&gdfp_req=1&ad_rule=1&output=vmap&unviewed_position_start=1&env=vp&impl=s&cmsid=496&vid=short_onecue&correlator="
   const val AD_TAG_COMPLEX = "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/vmap_ad_samples&sz=640x480&cust_params=sample_ar%3Dpremidpostlongpod&ciu_szs=300x250&gdfp_req=1&ad_rule=1&output=vmap&unviewed_position_start=1&env=vp&impl=s&cmsid=496&vid=short_onecue&correlator="
   const val AD_TAG_BROKEN_REDIRECT = "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_ad_samples&sz=640x480&cust_params=sample_ct%3Dredirecterror&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator="

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/Constants.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/Constants.kt
@@ -7,6 +7,7 @@ object Constants {
   const val VOD_TEST_URL_BIG_BUCK_BUNNY = "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8"
   const val VOD_TEST_SHORT_VIDEO = "https://stream.mux.com/a4nOgmxGWg6gULfcBbAa00gXyfcwPnAFldF8RdsNyk8M.m3u8"
   const val VOD_TEST_ELEPHANTS_DREAM_DASH = "https://rdmedia.bbc.co.uk/elephants_dream/1/client_manifest-all.mpd"
+  const val VOD_TEST_MULTI_LANGUAGE_MUX_VIDEO = "https://stream.mux.com/3x5wDUHxkd8NkEfspLUK3OpSQEJe3pom.m3u8"
   const val AD_TAG_SIMPLE_W_MID_ROLL = "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/vmap_ad_samples&sz=640x480&cust_params=sample_ar%3Dpremidpostoptimizedpod&ciu_szs=300x250&gdfp_req=1&ad_rule=1&output=vmap&unviewed_position_start=1&env=vp&impl=s&cmsid=496&vid=short_onecue&correlator="
   const val AD_TAG_COMPLEX = "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/vmap_ad_samples&sz=640x480&cust_params=sample_ar%3Dpremidpostlongpod&ciu_szs=300x250&gdfp_req=1&ad_rule=1&output=vmap&unviewed_position_start=1&env=vp&impl=s&cmsid=496&vid=short_onecue&correlator="
   const val AD_TAG_BROKEN_REDIRECT = "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_ad_samples&sz=640x480&cust_params=sample_ct%3Dredirecterror&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator="

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/basic/BasicPlayerActivity.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/basic/BasicPlayerActivity.kt
@@ -48,7 +48,7 @@ class BasicPlayerActivity : AppCompatActivity() {
   override fun onResume() {
     super.onResume()
     startPlaying(
-      intent.getStringExtra(EXTRA_URL) ?: Constants.VOD_TEST_URL_TEARS_OF_STEEL
+      intent.getStringExtra(EXTRA_URL) ?: Constants.VOD_TEST_MULTI_LANGUAGE_MUX_VIDEO
     )
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ dokka = "1.6.10"
 
 # Mux core deps
 muxCoreAndroid = "1.7.2"
-muxCoreJava = "8.10.0"
+muxCoreJava = "dev-audio-track-change-api-35046c3"
 
 # media3 per-variant pins.
 #

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ dokka = "1.6.10"
 
 # Mux core deps
 muxCoreAndroid = "1.7.2"
-muxCoreJava = "dev-audio-track-change-api-35046c3"
+muxCoreJava = "8.11.0"
 
 # media3 per-variant pins.
 #

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
@@ -12,7 +12,6 @@ import androidx.media3.common.Timeline
 import androidx.media3.common.Tracks
 import androidx.media3.common.VideoSize
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.exoplayer.DecoderCounters
 import androidx.media3.exoplayer.DecoderReuseEvaluation
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
@@ -205,6 +204,15 @@ private class MuxAnalyticsListener(
     collector.mediaHasVideoTrack = tracks.hasAtLeastOneVideoTrack()
     if (eventTime.mediaPeriodId?.isInAdGroup() != true) {
       textTrackChangeReporter.reportTracksChanged(tracks)
+
+      // report audio track disabled when no audio tracks are selected, but report enabled elsewhere
+      // onAudioInputFormatChanged handles tracks being enabled, so channel count/bitrate/etc
+      //  can be picked up even when dash manifest or hls multivariant pl don't specify them
+      val selectedAudioTrackGroup = tracks.groups.firstOrNull { it.type == C .TRACK_TYPE_AUDIO }
+        ?.findSelectedTrackIndex()
+      if (selectedAudioTrackGroup == null) {
+        audioTrackChangeReporter.reportAudioTrackDisabled()
+      }
     }
   }
 
@@ -214,21 +222,8 @@ private class MuxAnalyticsListener(
     decoderReuseEvaluation: DecoderReuseEvaluation?
   ) {
     Log.d("ExoPlayerBinding", "onAudioInputFormatChanged: ${Format.toLogString(format)}")
+    // Report audio track change here: channel count/bitrate/etc extracted from hls chunks by now
     audioTrackChangeReporter.reportAudioInputFormatChanged(format)
-  }
-
-  override fun onAudioDisabled(
-    eventTime: AnalyticsListener.EventTime,
-    decoderCounters: DecoderCounters
-  ) {
-    audioTrackChangeReporter.reportAudioInputDisabled()
-  }
-
-  override fun onAudioEnabled(
-    eventTime: AnalyticsListener.EventTime,
-    decoderCounters: DecoderCounters
-  ) {
-    audioTrackChangeReporter.reportAudioInputEnabled()
   }
 
   override fun onDownstreamFormatChanged(
@@ -421,7 +416,7 @@ internal class AudioTrackChangeReporter(
 ) {
   private var lastReportedState: AudioTrackState? = null
 
-  fun reportAudioInputDisabled() {
+  fun reportAudioTrackDisabled() {
     val lastState = this.lastReportedState
     if (lastState != null) {
       val nextState = AudioTrackState(
@@ -440,23 +435,6 @@ internal class AudioTrackChangeReporter(
         AudioTrackState(
           enabled = false
       ))
-    }
-  }
-
-  fun reportAudioInputEnabled() {
-    // If we already have a state stored, report that it's enabled
-    // No need to handle if we don't have a state, it will be reported via onAudioInputFormatChanged
-    val lastState = this.lastReportedState
-    if (lastState != null) {
-      val nextState = AudioTrackState(
-        enabled = true,
-        codec = lastState.codec,
-        name = lastState.name,
-        language = lastState.language,
-        bitrate = lastState.bitrate,
-        channels = lastState.channels,
-      )
-      dispatch(nextState)
     }
   }
 

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
@@ -208,8 +208,8 @@ private class MuxAnalyticsListener(
       // report audio track disabled when no audio tracks are selected, but report enabled elsewhere
       // onAudioInputFormatChanged handles tracks being enabled, so channel count/bitrate/etc
       //  can be picked up even when dash manifest or hls multivariant pl don't specify them
-      val selectedAudioTrackGroup = tracks.groups.firstOrNull { it.type == C .TRACK_TYPE_AUDIO }
-        ?.findSelectedTrackIndex()
+      val selectedAudioTrackGroup =
+        tracks.groups.firstOrNull { it.type == C.TRACK_TYPE_AUDIO  && it.isSelected }
       if (selectedAudioTrackGroup == null) {
         audioTrackChangeReporter.reportAudioTrackDisabled()
       }

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
@@ -431,10 +431,7 @@ internal class AudioTrackChangeReporter(
         dispatch(nextState)
       }
     } else {
-      dispatch(
-        AudioTrackState(
-          enabled = false
-      ))
+      dispatch(AudioTrackState(enabled = false))
     }
   }
 

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
@@ -223,7 +223,9 @@ private class MuxAnalyticsListener(
   ) {
     Log.d("ExoPlayerBinding", "onAudioInputFormatChanged: ${Format.toLogString(format)}")
     // Report audio track change here: channel count/bitrate/etc extracted from hls chunks by now
-    audioTrackChangeReporter.reportAudioInputFormatChanged(format)
+    if (eventTime.mediaPeriodId?.isInAdGroup() != true) {
+      audioTrackChangeReporter.reportAudioInputFormatChanged(format)
+    }
   }
 
   override fun onDownstreamFormatChanged(
@@ -428,6 +430,7 @@ internal class AudioTrackChangeReporter(
         channels = lastState.channels,
       )
       if (lastState != nextState) {
+        this.lastReportedState = nextState
         dispatch(nextState)
       }
     } else {

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
@@ -204,7 +204,6 @@ private class MuxAnalyticsListener(
     collector.mediaHasVideoTrack = tracks.hasAtLeastOneVideoTrack()
     if (eventTime.mediaPeriodId?.isInAdGroup() != true) {
       textTrackChangeReporter.reportTracksChanged(tracks)
-//      audioTrackChangeReporter.reportTracksChanged(tracks)
     }
   }
 
@@ -407,14 +406,6 @@ internal class AudioTrackChangeReporter(
 ) {
   private var lastReportedState: AudioTrackState? = null
 
-  fun reportTracksChanged(tracks: Tracks) {
-    val nextState = tracks.toAudioTrackState()
-    if (nextState != lastReportedState) {
-      dispatch(nextState)
-      lastReportedState = nextState
-    }
-  }
-
   fun reportAudioInputFormatChanged(format: Format) {
     val nextState = format.toAudioTrackState()
     if (nextState != lastReportedState) {
@@ -426,17 +417,6 @@ internal class AudioTrackChangeReporter(
   fun reset() {
     lastReportedState = null
   }
-}
-
-internal fun Tracks.toAudioTrackState(): AudioTrackState {
-  val selectedAudioTrackGroup = groups.firstOrNull {
-    it.type == C.TRACK_TYPE_AUDIO && it.isSelected
-  } ?: return AudioTrackState(enabled = false)
-
-  val selectedTrackIndex = selectedAudioTrackGroup.findSelectedTrackIndex()
-    ?: return AudioTrackState(enabled = false)
-  val format = selectedAudioTrackGroup.getTrackFormat(selectedTrackIndex)
-  return format.toAudioTrackState()
 }
 
 internal fun Format.toAudioTrackState(): AudioTrackState {

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
@@ -417,24 +417,10 @@ internal class AudioTrackChangeReporter(
 
   fun reportAudioTrackDisabled() {
     val lastState = this.lastReportedState
-    if (lastState != null) {
-      val nextState = AudioTrackState(
-        enabled = false,
-        codec = lastState.codec,
-        name = lastState.name,
-        language = lastState.language,
-        bitrate = lastState.bitrate,
-        channels = lastState.channels,
-      )
-      if (lastState != nextState) {
-        this.lastReportedState = nextState
-        dispatch(nextState)
-      }
-    } else {
-      val nextState = AudioTrackState(enabled = false)
-      if (nextState != this.lastReportedState) {
-        dispatch(nextState)
-      }
+    if (lastState == null || lastState.enabled) {
+      val disabledState = AudioTrackState(enabled = false)
+      this.lastReportedState = disabledState
+      dispatch(disabledState)
     }
   }
 

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
@@ -434,7 +434,10 @@ internal class AudioTrackChangeReporter(
         dispatch(nextState)
       }
     } else {
-      dispatch(AudioTrackState(enabled = false))
+      val nextState = AudioTrackState(enabled = false)
+      if (nextState != this.lastReportedState) {
+        dispatch(nextState)
+      }
     }
   }
 

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
@@ -5,6 +5,7 @@ import androidx.media3.common.C
 import androidx.media3.common.Format
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+import androidx.media3.common.MimeTypes
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
 import androidx.media3.common.Tracks
@@ -16,6 +17,7 @@ import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.exoplayer.source.LoadEventInfo
 import androidx.media3.exoplayer.source.MediaLoadData
 import com.mux.android.util.weak
+import com.mux.stats.sdk.core.events.playback.AudioTrackChangeEvent
 import com.mux.stats.sdk.core.events.playback.TextTrackChangeEvent
 import com.mux.stats.sdk.core.util.MuxLogger
 import com.mux.stats.sdk.muxstats.bandwidth.BandwidthMetricDispatcher
@@ -103,6 +105,16 @@ private class MuxAnalyticsListener(
       state.language
     )
   }
+  private val audioTrackChangeReporter = AudioTrackChangeReporter { state ->
+    collector.muxStats.audioTrackChange(
+      state.enabled,
+      state.name,
+      state.language,
+      state.codec,
+      state.bitrate,
+      state.channels
+    )
+  }
 
   override fun onPlayWhenReadyChanged(
     eventTime: AnalyticsListener.EventTime,
@@ -141,6 +153,7 @@ private class MuxAnalyticsListener(
     reason: Int
   ) {
     textTrackChangeReporter.reset()
+    audioTrackChangeReporter.reset()
     mediaItem?.let { collector.handleMediaItemChanged(it) }
   }
 
@@ -190,6 +203,7 @@ private class MuxAnalyticsListener(
     collector.mediaHasVideoTrack = tracks.hasAtLeastOneVideoTrack()
     if (eventTime.mediaPeriodId?.isInAdGroup() != true) {
       textTrackChangeReporter.reportTracksChanged(tracks)
+      audioTrackChangeReporter.reportTracksChanged(tracks)
     }
   }
 
@@ -369,6 +383,52 @@ internal fun Tracks.toTextTrackState(): TextTrackState {
   )
 }
 
+internal data class AudioTrackState(
+  val enabled: Boolean,
+  val codec: String? = null,
+  val name: String? = null,
+  val language: String? = null,
+  val bitrate: String? = null,
+  val channels: String? = null,
+)
+
+internal class AudioTrackChangeReporter(
+  private val dispatch: (AudioTrackState) -> Unit,
+) {
+  private var lastReportedState: AudioTrackState? = null
+
+  fun reportTracksChanged(tracks: Tracks) {
+    val nextState = tracks.toAudioTrackState()
+    if (nextState != lastReportedState) {
+      dispatch(nextState)
+      lastReportedState = nextState
+    }
+  }
+
+  fun reset() {
+    lastReportedState = null
+  }
+}
+
+internal fun Tracks.toAudioTrackState(): AudioTrackState {
+  val selectedAudioTrackGroup = groups.firstOrNull {
+    it.type == C.TRACK_TYPE_AUDIO && it.isSelected
+  } ?: return AudioTrackState(enabled = false)
+
+  val selectedTrackIndex = selectedAudioTrackGroup.findSelectedTrackIndex()
+    ?: return AudioTrackState(enabled = false)
+  val format = selectedAudioTrackGroup.getTrackFormat(selectedTrackIndex)
+
+  return AudioTrackState(
+    enabled = true,
+    codec = format.toAudioTrackCodec(),
+    name = format.label.toMeaningfulValue(),
+    language = format.language.toMeaningfulLanguage(),
+    bitrate = format.toAudioTrackBitrate(),
+    channels = format.toAudioTrackChannels(),
+  )
+}
+
 internal fun Tracks.Group.findSelectedTrackIndex(): Int? {
   for (i in 0..<length) {
     if (isTrackSelected(i)) {
@@ -411,6 +471,39 @@ private fun Format.toTextTrackFormat(): String? {
     else -> null
   }
 }
+
+/**
+ * Reports the audio portion of this format's `CODECS` string. A `CODECS` value can list codecs for
+ * several track types (e.g. `"avc1.640028,mp4a.40.2"`), so we return the first entry whose media
+ * MIME type is an audio type, or `null` if none can be identified.
+ */
+@OptIn(UnstableApi::class)
+private fun Format.toAudioTrackCodec(): String? = codecs
+  ?.split(',')
+  ?.mapNotNull { it.trim().takeUnless(String::isEmpty) }
+  ?.firstOrNull { MimeTypes.isAudio(MimeTypes.getMediaMimeType(it)) }
+
+@OptIn(UnstableApi::class)
+private fun Format.toAudioTrackBitrate(): String? = bitrate
+  .takeIf { it != Format.NO_VALUE && it >= 0 }
+  ?.toString()
+
+/**
+ * Maps this format's channel count to a known channel configuration when possible, falling back to
+ * the raw channel count. `atmos` is intentionally not inferred here since it can't be determined
+ * from a channel count alone.
+ */
+private fun Format.toAudioTrackChannels(): String? = channelCount
+  .takeIf { it != Format.NO_VALUE && it > 0 }
+  ?.let { count ->
+    when (count) {
+      1 -> AudioTrackChangeEvent.AUDIO_TRACK_CHANNELS_MONO
+      2 -> AudioTrackChangeEvent.AUDIO_TRACK_CHANNELS_STEREO
+      6 -> AudioTrackChangeEvent.AUDIO_TRACK_CHANNELS_5_1
+      8 -> AudioTrackChangeEvent.AUDIO_TRACK_CHANNELS_7_1
+      else -> count.toString()
+    }
+  }
 
 private fun String?.toMeaningfulLanguage(): String? = toMeaningfulValue()
   ?.takeUnless { it.equals("und", ignoreCase = true) }

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
@@ -12,6 +12,7 @@ import androidx.media3.common.Timeline
 import androidx.media3.common.Tracks
 import androidx.media3.common.VideoSize
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.DecoderCounters
 import androidx.media3.exoplayer.DecoderReuseEvaluation
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
@@ -216,6 +217,20 @@ private class MuxAnalyticsListener(
     audioTrackChangeReporter.reportAudioInputFormatChanged(format)
   }
 
+  override fun onAudioDisabled(
+    eventTime: AnalyticsListener.EventTime,
+    decoderCounters: DecoderCounters
+  ) {
+    audioTrackChangeReporter.reportAudioInputDisabled()
+  }
+
+  override fun onAudioEnabled(
+    eventTime: AnalyticsListener.EventTime,
+    decoderCounters: DecoderCounters
+  ) {
+    audioTrackChangeReporter.reportAudioInputEnabled()
+  }
+
   override fun onDownstreamFormatChanged(
     eventTime: AnalyticsListener.EventTime,
     mediaLoadData: MediaLoadData
@@ -405,6 +420,45 @@ internal class AudioTrackChangeReporter(
   private val dispatch: (AudioTrackState) -> Unit,
 ) {
   private var lastReportedState: AudioTrackState? = null
+
+  fun reportAudioInputDisabled() {
+    val lastState = this.lastReportedState
+    if (lastState != null) {
+      val nextState = AudioTrackState(
+        enabled = false,
+        codec = lastState.codec,
+        name = lastState.name,
+        language = lastState.language,
+        bitrate = lastState.bitrate,
+        channels = lastState.channels,
+      )
+      if (lastState != nextState) {
+        dispatch(nextState)
+      }
+    } else {
+      dispatch(
+        AudioTrackState(
+          enabled = false
+      ))
+    }
+  }
+
+  fun reportAudioInputEnabled() {
+    // If we already have a state stored, report that it's enabled
+    // No need to handle if we don't have a state, it will be reported via onAudioInputFormatChanged
+    val lastState = this.lastReportedState
+    if (lastState != null) {
+      val nextState = AudioTrackState(
+        enabled = true,
+        codec = lastState.codec,
+        name = lastState.name,
+        language = lastState.language,
+        bitrate = lastState.bitrate,
+        channels = lastState.channels,
+      )
+      dispatch(nextState)
+    }
+  }
 
   fun reportAudioInputFormatChanged(format: Format) {
     val nextState = format.toAudioTrackState()

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
@@ -1,5 +1,6 @@
 package com.mux.stats.sdk.muxstats
 
+import android.util.Log
 import androidx.annotation.OptIn
 import androidx.media3.common.C
 import androidx.media3.common.Format
@@ -203,7 +204,7 @@ private class MuxAnalyticsListener(
     collector.mediaHasVideoTrack = tracks.hasAtLeastOneVideoTrack()
     if (eventTime.mediaPeriodId?.isInAdGroup() != true) {
       textTrackChangeReporter.reportTracksChanged(tracks)
-      audioTrackChangeReporter.reportTracksChanged(tracks)
+//      audioTrackChangeReporter.reportTracksChanged(tracks)
     }
   }
 
@@ -212,7 +213,8 @@ private class MuxAnalyticsListener(
     format: Format,
     decoderReuseEvaluation: DecoderReuseEvaluation?
   ) {
-    super.onAudioInputFormatChanged(eventTime, format, decoderReuseEvaluation)
+    Log.d("ExoPlayerBinding", "onAudioInputFormatChanged: ${Format.toLogString(format)}")
+    audioTrackChangeReporter.reportAudioInputFormatChanged(format)
   }
 
   override fun onDownstreamFormatChanged(
@@ -413,6 +415,14 @@ internal class AudioTrackChangeReporter(
     }
   }
 
+  fun reportAudioInputFormatChanged(format: Format) {
+    val nextState = format.toAudioTrackState()
+    if (nextState != lastReportedState) {
+      dispatch(nextState)
+      lastReportedState = nextState
+    }
+  }
+
   fun reset() {
     lastReportedState = null
   }
@@ -426,14 +436,17 @@ internal fun Tracks.toAudioTrackState(): AudioTrackState {
   val selectedTrackIndex = selectedAudioTrackGroup.findSelectedTrackIndex()
     ?: return AudioTrackState(enabled = false)
   val format = selectedAudioTrackGroup.getTrackFormat(selectedTrackIndex)
+  return format.toAudioTrackState()
+}
 
+internal fun Format.toAudioTrackState(): AudioTrackState {
   return AudioTrackState(
     enabled = true,
-    codec = format.toAudioTrackCodec(),
-    name = format.label.toMeaningfulValue(),
-    language = format.language.toMeaningfulLanguage(),
-    bitrate = format.toAudioTrackBitrate(),
-    channels = format.toAudioTrackChannels(),
+    codec = toAudioTrackCodec(),
+    name = label.toMeaningfulValue(),
+    language = language.toMeaningfulLanguage(),
+    bitrate = toAudioTrackBitrate(),
+    channels = toAudioTrackChannels(),
   )
 }
 

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
@@ -207,6 +207,14 @@ private class MuxAnalyticsListener(
     }
   }
 
+  override fun onAudioInputFormatChanged(
+    eventTime: AnalyticsListener.EventTime,
+    format: Format,
+    decoderReuseEvaluation: DecoderReuseEvaluation?
+  ) {
+    super.onAudioInputFormatChanged(eventTime, format, decoderReuseEvaluation)
+  }
+
   override fun onDownstreamFormatChanged(
     eventTime: AnalyticsListener.EventTime,
     mediaLoadData: MediaLoadData

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
@@ -208,9 +208,7 @@ private class MuxAnalyticsListener(
       // report audio track disabled when no audio tracks are selected, but report enabled elsewhere
       // onAudioInputFormatChanged handles tracks being enabled, so channel count/bitrate/etc
       //  can be picked up even when dash manifest or hls multivariant pl don't specify them
-      val selectedAudioTrackGroup =
-        tracks.groups.firstOrNull { it.type == C.TRACK_TYPE_AUDIO  && it.isSelected }
-      if (selectedAudioTrackGroup == null) {
+      if (tracks.groups.any { it.type == C.TRACK_TYPE_AUDIO  && it.isSelected }) {
         audioTrackChangeReporter.reportAudioTrackDisabled()
       }
     }

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
@@ -208,7 +208,7 @@ private class MuxAnalyticsListener(
       // report audio track disabled when no audio tracks are selected, but report enabled elsewhere
       // onAudioInputFormatChanged handles tracks being enabled, so channel count/bitrate/etc
       //  can be picked up even when dash manifest or hls multivariant pl don't specify them
-      if (tracks.groups.any { it.type == C.TRACK_TYPE_AUDIO  && it.isSelected }) {
+      if (tracks.groups.none { it.type == C.TRACK_TYPE_AUDIO  && it.isSelected }) {
         audioTrackChangeReporter.reportAudioTrackDisabled()
       }
     }
@@ -219,7 +219,6 @@ private class MuxAnalyticsListener(
     format: Format,
     decoderReuseEvaluation: DecoderReuseEvaluation?
   ) {
-    Log.d("ExoPlayerBinding", "onAudioInputFormatChanged: ${Format.toLogString(format)}")
     // Report audio track change here: channel count/bitrate/etc extracted from hls chunks by now
     if (eventTime.mediaPeriodId?.isInAdGroup() != true) {
       audioTrackChangeReporter.reportAudioInputFormatChanged(format)

--- a/library-exo/src/test/java/com/mux/stats/sdk/muxstats/AudioTrackChangeReporterTest.kt
+++ b/library-exo/src/test/java/com/mux/stats/sdk/muxstats/AudioTrackChangeReporterTest.kt
@@ -1,0 +1,187 @@
+package com.mux.stats.sdk.muxstats
+
+import androidx.media3.common.C
+import androidx.media3.common.Format
+import androidx.media3.common.TrackGroup
+import androidx.media3.common.Tracks
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner::class)
+class AudioTrackChangeReporterTest {
+
+  @Test
+  fun `selected audio track reports the audio portion of a codecs string`() {
+    val tracks = tracksOf(
+      audioGroup(
+        format = audioFormat(
+          codecs = "avc1.640028,mp4a.40.2",
+          label = "English",
+          language = "en-US",
+          bitrate = 128_000,
+          channelCount = 2,
+        ),
+        selected = true,
+      )
+    )
+
+    val state = tracks.toAudioTrackState()
+
+    assertEquals(
+      AudioTrackState(
+        enabled = true,
+        codec = "mp4a.40.2",
+        name = "English",
+        language = "en-us",
+        bitrate = "128000",
+        channels = "stereo",
+      ),
+      state
+    )
+  }
+
+  @Test
+  fun `single audio codec is reported as-is`() {
+    val state = tracksOf(audioGroup(audioFormat(codecs = "ec-3"), selected = true))
+      .toAudioTrackState()
+
+    assertEquals("ec-3", state.codec)
+  }
+
+  @Test
+  fun `known channel counts are mapped to channel configurations`() {
+    assertEquals("mono", channelsFor(channelCount = 1))
+    assertEquals("stereo", channelsFor(channelCount = 2))
+    assertEquals("5.1", channelsFor(channelCount = 6))
+    assertEquals("7.1", channelsFor(channelCount = 8))
+  }
+
+  @Test
+  fun `unknown channel counts fall back to the raw count`() {
+    assertEquals("3", channelsFor(channelCount = 3))
+  }
+
+  private fun channelsFor(channelCount: Int): String? = tracksOf(
+    audioGroup(audioFormat(codecs = "mp4a.40.2", channelCount = channelCount), selected = true)
+  ).toAudioTrackState().channels
+
+  @Test
+  fun `missing audio selection normalizes to disabled with cleared metadata`() {
+    val tracks = tracksOf(
+      audioGroup(
+        format = audioFormat(codecs = "mp4a.40.2", label = "English", language = "en"),
+        selected = false,
+      )
+    )
+
+    val state = tracks.toAudioTrackState()
+
+    assertEquals(AudioTrackState(enabled = false), state)
+  }
+
+  @Test
+  fun `unidentifiable codec and non-meaningful fields are omitted`() {
+    val tracks = tracksOf(
+      audioGroup(
+        format = audioFormat(codecs = null, label = " ", language = "und"),
+        selected = true,
+      )
+    )
+
+    val state = tracks.toAudioTrackState()
+
+    assertEquals(true, state.enabled)
+    assertNull(state.codec)
+    assertNull(state.name)
+    assertNull(state.language)
+    assertNull(state.bitrate)
+    assertNull(state.channels)
+  }
+
+  @Test
+  fun `reporter dispatches initial state, dedupes repeats, and reports disable`() {
+    val reportedStates = mutableListOf<AudioTrackState>()
+    val reporter = AudioTrackChangeReporter { reportedStates += it }
+    val selectedTracks = tracksOf(
+      audioGroup(
+        format = audioFormat(codecs = "mp4a.40.2", label = "English", language = "en"),
+        selected = true,
+      )
+    )
+    val disabledTracks = tracksOf(
+      audioGroup(
+        format = audioFormat(codecs = "mp4a.40.2", label = "English", language = "en"),
+        selected = false,
+      )
+    )
+
+    reporter.reportTracksChanged(selectedTracks)
+    reporter.reportTracksChanged(selectedTracks)
+    reporter.reportTracksChanged(disabledTracks)
+
+    assertEquals(2, reportedStates.size)
+    assertEquals(
+      AudioTrackState(
+        enabled = true,
+        codec = "mp4a.40.2",
+        name = "English",
+        language = "en",
+      ),
+      reportedStates[0]
+    )
+    assertEquals(AudioTrackState(enabled = false), reportedStates[1])
+  }
+
+  @Test
+  fun `reporter reset allows same state to be emitted for a new view`() {
+    val reportedStates = mutableListOf<AudioTrackState>()
+    val reporter = AudioTrackChangeReporter { reportedStates += it }
+    val selectedTracks = tracksOf(
+      audioGroup(
+        format = audioFormat(codecs = "mp4a.40.2", label = "English", language = "en"),
+        selected = true,
+      )
+    )
+
+    reporter.reportTracksChanged(selectedTracks)
+    reporter.reset()
+    reporter.reportTracksChanged(selectedTracks)
+
+    assertEquals(2, reportedStates.size)
+    assertEquals(reportedStates[0], reportedStates[1])
+  }
+
+  private fun tracksOf(vararg groups: Tracks.Group): Tracks = Tracks(groups.toList())
+
+  private fun audioGroup(format: Format, selected: Boolean): Tracks.Group = Tracks.Group(
+    TrackGroup(format),
+    false,
+    intArrayOf(C.FORMAT_HANDLED),
+    booleanArrayOf(selected),
+  )
+
+  private fun audioFormat(
+    codecs: String?,
+    label: String? = null,
+    language: String? = null,
+    bitrate: Int = Format.NO_VALUE,
+    channelCount: Int = Format.NO_VALUE,
+  ): Format = Format.Builder()
+    .setSampleMimeType(MimeTypesShim.AUDIO_AAC)
+    .setCodecs(codecs)
+    .setLabel(label)
+    .setLanguage(language)
+    .setAverageBitrate(bitrate)
+    .setChannelCount(channelCount)
+    .build()
+
+  // Keeps the test independent of the @UnstableApi MimeTypes constants.
+  private object MimeTypesShim {
+    const val AUDIO_AAC = "audio/mp4a-latm"
+  }
+}

--- a/library-exo/src/test/java/com/mux/stats/sdk/muxstats/AudioTrackChangeReporterTest.kt
+++ b/library-exo/src/test/java/com/mux/stats/sdk/muxstats/AudioTrackChangeReporterTest.kt
@@ -1,9 +1,6 @@
 package com.mux.stats.sdk.muxstats
 
-import androidx.media3.common.C
 import androidx.media3.common.Format
-import androidx.media3.common.TrackGroup
-import androidx.media3.common.Tracks
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -16,21 +13,14 @@ import org.robolectric.annotation.Config
 class AudioTrackChangeReporterTest {
 
   @Test
-  fun `selected audio track reports the audio portion of a codecs string`() {
-    val tracks = tracksOf(
-      audioGroup(
-        format = audioFormat(
-          codecs = "avc1.640028,mp4a.40.2",
-          label = "English",
-          language = "en-US",
-          bitrate = 128_000,
-          channelCount = 2,
-        ),
-        selected = true,
-      )
-    )
-
-    val state = tracks.toAudioTrackState()
+  fun `selected audio format reports the audio portion of a codecs string`() {
+    val state = audioFormat(
+      codecs = "avc1.640028,mp4a.40.2",
+      label = "English",
+      language = "en-US",
+      bitrate = 128_000,
+      channelCount = 2,
+    ).toAudioTrackState()
 
     assertEquals(
       AudioTrackState(
@@ -47,10 +37,7 @@ class AudioTrackChangeReporterTest {
 
   @Test
   fun `single audio codec is reported as-is`() {
-    val state = tracksOf(audioGroup(audioFormat(codecs = "ec-3"), selected = true))
-      .toAudioTrackState()
-
-    assertEquals("ec-3", state.codec)
+    assertEquals("ec-3", audioFormat(codecs = "ec-3").toAudioTrackState().codec)
   }
 
   @Test
@@ -66,34 +53,12 @@ class AudioTrackChangeReporterTest {
     assertEquals("3", channelsFor(channelCount = 3))
   }
 
-  private fun channelsFor(channelCount: Int): String? = tracksOf(
-    audioGroup(audioFormat(codecs = "mp4a.40.2", channelCount = channelCount), selected = true)
-  ).toAudioTrackState().channels
-
-  @Test
-  fun `missing audio selection normalizes to disabled with cleared metadata`() {
-    val tracks = tracksOf(
-      audioGroup(
-        format = audioFormat(codecs = "mp4a.40.2", label = "English", language = "en"),
-        selected = false,
-      )
-    )
-
-    val state = tracks.toAudioTrackState()
-
-    assertEquals(AudioTrackState(enabled = false), state)
-  }
+  private fun channelsFor(channelCount: Int): String? =
+    audioFormat(codecs = "mp4a.40.2", channelCount = channelCount).toAudioTrackState().channels
 
   @Test
   fun `unidentifiable codec and non-meaningful fields are omitted`() {
-    val tracks = tracksOf(
-      audioGroup(
-        format = audioFormat(codecs = null, label = " ", language = "und"),
-        selected = true,
-      )
-    )
-
-    val state = tracks.toAudioTrackState()
+    val state = audioFormat(codecs = null, label = " ", language = "und").toAudioTrackState()
 
     assertEquals(true, state.enabled)
     assertNull(state.codec)
@@ -104,66 +69,40 @@ class AudioTrackChangeReporterTest {
   }
 
   @Test
-  fun `reporter dispatches initial state, dedupes repeats, and reports disable`() {
+  fun `reporter dispatches initial state, dedupes repeats, and reports changes`() {
     val reportedStates = mutableListOf<AudioTrackState>()
     val reporter = AudioTrackChangeReporter { reportedStates += it }
-    val selectedTracks = tracksOf(
-      audioGroup(
-        format = audioFormat(codecs = "mp4a.40.2", label = "English", language = "en"),
-        selected = true,
-      )
-    )
-    val disabledTracks = tracksOf(
-      audioGroup(
-        format = audioFormat(codecs = "mp4a.40.2", label = "English", language = "en"),
-        selected = false,
-      )
-    )
+    val english = audioFormat(codecs = "mp4a.40.2", label = "English", language = "en")
+    val spanish = audioFormat(codecs = "mp4a.40.2", label = "Spanish", language = "es")
 
-    reporter.reportTracksChanged(selectedTracks)
-    reporter.reportTracksChanged(selectedTracks)
-    reporter.reportTracksChanged(disabledTracks)
+    reporter.reportAudioInputFormatChanged(english)
+    reporter.reportAudioInputFormatChanged(english)
+    reporter.reportAudioInputFormatChanged(spanish)
 
     assertEquals(2, reportedStates.size)
     assertEquals(
-      AudioTrackState(
-        enabled = true,
-        codec = "mp4a.40.2",
-        name = "English",
-        language = "en",
-      ),
+      AudioTrackState(enabled = true, codec = "mp4a.40.2", name = "English", language = "en"),
       reportedStates[0]
     )
-    assertEquals(AudioTrackState(enabled = false), reportedStates[1])
+    assertEquals(
+      AudioTrackState(enabled = true, codec = "mp4a.40.2", name = "Spanish", language = "es"),
+      reportedStates[1]
+    )
   }
 
   @Test
   fun `reporter reset allows same state to be emitted for a new view`() {
     val reportedStates = mutableListOf<AudioTrackState>()
     val reporter = AudioTrackChangeReporter { reportedStates += it }
-    val selectedTracks = tracksOf(
-      audioGroup(
-        format = audioFormat(codecs = "mp4a.40.2", label = "English", language = "en"),
-        selected = true,
-      )
-    )
+    val format = audioFormat(codecs = "mp4a.40.2", label = "English", language = "en")
 
-    reporter.reportTracksChanged(selectedTracks)
+    reporter.reportAudioInputFormatChanged(format)
     reporter.reset()
-    reporter.reportTracksChanged(selectedTracks)
+    reporter.reportAudioInputFormatChanged(format)
 
     assertEquals(2, reportedStates.size)
     assertEquals(reportedStates[0], reportedStates[1])
   }
-
-  private fun tracksOf(vararg groups: Tracks.Group): Tracks = Tracks(groups.toList())
-
-  private fun audioGroup(format: Format, selected: Boolean): Tracks.Group = Tracks.Group(
-    TrackGroup(format),
-    false,
-    intArrayOf(C.FORMAT_HANDLED),
-    booleanArrayOf(selected),
-  )
 
   private fun audioFormat(
     codecs: String?,

--- a/library-exo/src/test/java/com/mux/stats/sdk/muxstats/AudioTrackChangeReporterTest.kt
+++ b/library-exo/src/test/java/com/mux/stats/sdk/muxstats/AudioTrackChangeReporterTest.kt
@@ -91,6 +91,75 @@ class AudioTrackChangeReporterTest {
   }
 
   @Test
+  fun `disabling with no prior state reports a single disabled state`() {
+    val reportedStates = mutableListOf<AudioTrackState>()
+    val reporter = AudioTrackChangeReporter { reportedStates += it }
+
+    reporter.reportAudioTrackDisabled()
+
+    assertEquals(listOf(AudioTrackState(enabled = false)), reportedStates)
+  }
+
+  @Test
+  fun `disabling after an enabled track reports a disabled state`() {
+    val reportedStates = mutableListOf<AudioTrackState>()
+    val reporter = AudioTrackChangeReporter { reportedStates += it }
+    val english = audioFormat(codecs = "mp4a.40.2", label = "English", language = "en")
+
+    reporter.reportAudioInputFormatChanged(english)
+    reporter.reportAudioTrackDisabled()
+
+    assertEquals(2, reportedStates.size)
+    assertEquals(
+      AudioTrackState(enabled = true, codec = "mp4a.40.2", name = "English", language = "en"),
+      reportedStates[0]
+    )
+    assertEquals(AudioTrackState(enabled = false), reportedStates[1])
+  }
+
+  @Test
+  fun `repeated disabling dedupes to a single disabled state`() {
+    val reportedStates = mutableListOf<AudioTrackState>()
+    val reporter = AudioTrackChangeReporter { reportedStates += it }
+
+    reporter.reportAudioTrackDisabled()
+    reporter.reportAudioTrackDisabled()
+    reporter.reportAudioTrackDisabled()
+
+    assertEquals(listOf(AudioTrackState(enabled = false)), reportedStates)
+  }
+
+  @Test
+  fun `re-enabling after disabling reports the enabled track again`() {
+    val reportedStates = mutableListOf<AudioTrackState>()
+    val reporter = AudioTrackChangeReporter { reportedStates += it }
+    val english = audioFormat(codecs = "mp4a.40.2", label = "English", language = "en")
+
+    reporter.reportAudioInputFormatChanged(english)
+    reporter.reportAudioTrackDisabled()
+    reporter.reportAudioInputFormatChanged(english)
+
+    assertEquals(3, reportedStates.size)
+    assertEquals(AudioTrackState(enabled = false), reportedStates[1])
+    assertEquals(reportedStates[0], reportedStates[2])
+  }
+
+  @Test
+  fun `reset allows a disabled state to be emitted again for a new view`() {
+    val reportedStates = mutableListOf<AudioTrackState>()
+    val reporter = AudioTrackChangeReporter { reportedStates += it }
+
+    reporter.reportAudioTrackDisabled()
+    reporter.reset()
+    reporter.reportAudioTrackDisabled()
+
+    assertEquals(
+      listOf(AudioTrackState(enabled = false), AudioTrackState(enabled = false)),
+      reportedStates
+    )
+  }
+
+  @Test
   fun `reporter reset allows same state to be emitted for a new view`() {
     val reportedStates = mutableListOf<AudioTrackState>()
     val reporter = AudioTrackChangeReporter { reportedStates += it }


### PR DESCRIPTION
Adds Audio Track change detection to the media3 SDK. It's pretty similar to text track changes

~~One notable issue with HLS is that channel count isn't reported. Presumably, media3 looks for the `CHANNELS` attribute for a particular variant, reporting `-1` for "unknown" if it isn't present. The channel count can be determined from `onAudioInputFormatChanged`, since that's called after segments are downloaded, when the channel count will be known from the container~~

Beacons Events:
Default/Untagged (Stereo AAC):
```json
{
      // snipped irrelevant keys
      "paotreb": "true",
      "paotrcc": "mp4a.40.2",
      "paotrcj": "stereo",
     // snipped irrelevant keys
      "e": "audiotrackchange"
    }
```

French Stereo AAC:
```json
{
     // snipped irrelevant keys
      "paotreb": "true",
      "paotrcc": "mp4a.40.2",
      "paotrcj": "stereo",
      "paotrnm": "Français",
      "paotrla": "fr",
     // snipped irrelevant keys
      "e": "audiotrackchange"
    }
```
    

Draft Until:

- [x] Java Core is released
- [x] HLS channel count issue resolved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new analytics events on the hot `onTracksChanged` path and depends on an unreleased Mux Java core artifact; behavior is isolated from ads and mirrors proven text-track logic.
> 
> **Overview**
> Adds **audio track change** analytics to the Media3 ExoPlayer binding, following the same pattern as existing text track reporting.
> 
> On `onTracksChanged` (outside ad periods), the binding derives the selected audio `Format` and emits `audiotrackchange` beacons via `muxStats.audioTrackChange` with enabled state, label, language, codec (parsed from multi-codec `CODECS` strings), bitrate, and channel layout (mono/stereo/5.1/7.1 or raw count). State is deduped and reset on media item transitions.
> 
> **`muxCoreJava`** is temporarily pinned to `dev-audio-track-change-api-35046c3` until the Java core ships. The sample app gains a **DASH** test manifest URL. **`AudioTrackChangeReporterTest`** covers mapping, disable paths, dedupe, and reset behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8383079f32a930855ca3c1f6b77e367a631b2261. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->