### PR TITLE
Releases/v1.13.0

### DIFF
--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/Constants.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/Constants.kt
@@ -6,6 +6,8 @@ object Constants {
   const val VOD_TEST_URL_TEARS_OF_STEEL = "https://stream.mux.com/u02xH9SB1ZZNNjPiQp4l6mhzBKJ101uExYx4LU02J5Xm88.m3u8"
   const val VOD_TEST_URL_BIG_BUCK_BUNNY = "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8"
   const val VOD_TEST_SHORT_VIDEO = "https://stream.mux.com/a4nOgmxGWg6gULfcBbAa00gXyfcwPnAFldF8RdsNyk8M.m3u8"
+  const val VOD_TEST_ELEPHANTS_DREAM_DASH = "https://rdmedia.bbc.co.uk/elephants_dream/1/client_manifest-all.mpd"
+  const val VOD_TEST_MULTI_LANGUAGE_MUX_VIDEO = "https://stream.mux.com/3x5wDUHxkd8NkEfspLUK3OpSQEJe3pom.m3u8"
   const val AD_TAG_SIMPLE_W_MID_ROLL = "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/vmap_ad_samples&sz=640x480&cust_params=sample_ar%3Dpremidpostoptimizedpod&ciu_szs=300x250&gdfp_req=1&ad_rule=1&output=vmap&unviewed_position_start=1&env=vp&impl=s&cmsid=496&vid=short_onecue&correlator="
   const val AD_TAG_COMPLEX = "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/vmap_ad_samples&sz=640x480&cust_params=sample_ar%3Dpremidpostlongpod&ciu_szs=300x250&gdfp_req=1&ad_rule=1&output=vmap&unviewed_position_start=1&env=vp&impl=s&cmsid=496&vid=short_onecue&correlator="
   const val AD_TAG_BROKEN_REDIRECT = "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_ad_samples&sz=640x480&cust_params=sample_ct%3Dredirecterror&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator="

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/basic/BasicPlayerActivity.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/basic/BasicPlayerActivity.kt
@@ -48,7 +48,7 @@ class BasicPlayerActivity : AppCompatActivity() {
   override fun onResume() {
     super.onResume()
     startPlaying(
-      intent.getStringExtra(EXTRA_URL) ?: Constants.VOD_TEST_MULTI_LANGUAGE_MUX_VIDEO
+      intent.getStringExtra(EXTRA_URL) ?: Constants.VOD_TEST_URL_TEARS_OF_STEEL
     )
   }
 

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/basic/BasicPlayerActivity.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/basic/BasicPlayerActivity.kt
@@ -48,7 +48,7 @@ class BasicPlayerActivity : AppCompatActivity() {
   override fun onResume() {
     super.onResume()
     startPlaying(
-      intent.getStringExtra(EXTRA_URL) ?: Constants.VOD_TEST_URL_TEARS_OF_STEEL
+      intent.getStringExtra(EXTRA_URL) ?: Constants.VOD_TEST_MULTI_LANGUAGE_MUX_VIDEO
     )
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ dokka = "1.6.10"
 
 # Mux core deps
 muxCoreAndroid = "1.7.2"
-muxCoreJava = "8.10.0"
+muxCoreJava = "8.11.0"
 
 # media3 per-variant pins.
 #

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/ExoPlayerBinding.kt
@@ -1,10 +1,12 @@
 package com.mux.stats.sdk.muxstats
 
+import android.util.Log
 import androidx.annotation.OptIn
 import androidx.media3.common.C
 import androidx.media3.common.Format
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+import androidx.media3.common.MimeTypes
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
 import androidx.media3.common.Tracks
@@ -16,6 +18,7 @@ import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.exoplayer.source.LoadEventInfo
 import androidx.media3.exoplayer.source.MediaLoadData
 import com.mux.android.util.weak
+import com.mux.stats.sdk.core.events.playback.AudioTrackChangeEvent
 import com.mux.stats.sdk.core.events.playback.TextTrackChangeEvent
 import com.mux.stats.sdk.core.util.MuxLogger
 import com.mux.stats.sdk.muxstats.bandwidth.BandwidthMetricDispatcher
@@ -103,6 +106,16 @@ private class MuxAnalyticsListener(
       state.language
     )
   }
+  private val audioTrackChangeReporter = AudioTrackChangeReporter { state ->
+    collector.muxStats.audioTrackChange(
+      state.enabled,
+      state.name,
+      state.language,
+      state.codec,
+      state.bitrate,
+      state.channels
+    )
+  }
 
   override fun onPlayWhenReadyChanged(
     eventTime: AnalyticsListener.EventTime,
@@ -141,6 +154,7 @@ private class MuxAnalyticsListener(
     reason: Int
   ) {
     textTrackChangeReporter.reset()
+    audioTrackChangeReporter.reset()
     mediaItem?.let { collector.handleMediaItemChanged(it) }
   }
 
@@ -190,6 +204,24 @@ private class MuxAnalyticsListener(
     collector.mediaHasVideoTrack = tracks.hasAtLeastOneVideoTrack()
     if (eventTime.mediaPeriodId?.isInAdGroup() != true) {
       textTrackChangeReporter.reportTracksChanged(tracks)
+
+      // report audio track disabled when no audio tracks are selected, but report enabled elsewhere
+      // onAudioInputFormatChanged handles tracks being enabled, so channel count/bitrate/etc
+      //  can be picked up even when dash manifest or hls multivariant pl don't specify them
+      if (tracks.groups.none { it.type == C.TRACK_TYPE_AUDIO  && it.isSelected }) {
+        audioTrackChangeReporter.reportAudioTrackDisabled()
+      }
+    }
+  }
+
+  override fun onAudioInputFormatChanged(
+    eventTime: AnalyticsListener.EventTime,
+    format: Format,
+    decoderReuseEvaluation: DecoderReuseEvaluation?
+  ) {
+    // Report audio track change here: channel count/bitrate/etc extracted from hls chunks by now
+    if (eventTime.mediaPeriodId?.isInAdGroup() != true) {
+      audioTrackChangeReporter.reportAudioInputFormatChanged(format)
     }
   }
 
@@ -369,6 +401,53 @@ internal fun Tracks.toTextTrackState(): TextTrackState {
   )
 }
 
+internal data class AudioTrackState(
+  val enabled: Boolean,
+  val codec: String? = null,
+  val name: String? = null,
+  val language: String? = null,
+  val bitrate: String? = null,
+  val channels: String? = null,
+)
+
+internal class AudioTrackChangeReporter(
+  private val dispatch: (AudioTrackState) -> Unit,
+) {
+  private var lastReportedState: AudioTrackState? = null
+
+  fun reportAudioTrackDisabled() {
+    val lastState = this.lastReportedState
+    if (lastState == null || lastState.enabled) {
+      val disabledState = AudioTrackState(enabled = false)
+      this.lastReportedState = disabledState
+      dispatch(disabledState)
+    }
+  }
+
+  fun reportAudioInputFormatChanged(format: Format) {
+    val nextState = format.toAudioTrackState()
+    if (nextState != lastReportedState) {
+      dispatch(nextState)
+      lastReportedState = nextState
+    }
+  }
+
+  fun reset() {
+    lastReportedState = null
+  }
+}
+
+internal fun Format.toAudioTrackState(): AudioTrackState {
+  return AudioTrackState(
+    enabled = true,
+    codec = toAudioTrackCodec(),
+    name = label.toMeaningfulValue(),
+    language = language.toMeaningfulLanguage(),
+    bitrate = toAudioTrackBitrate(),
+    channels = toAudioTrackChannels(),
+  )
+}
+
 internal fun Tracks.Group.findSelectedTrackIndex(): Int? {
   for (i in 0..<length) {
     if (isTrackSelected(i)) {
@@ -411,6 +490,39 @@ private fun Format.toTextTrackFormat(): String? {
     else -> null
   }
 }
+
+/**
+ * Reports the audio portion of this format's `CODECS` string. A `CODECS` value can list codecs for
+ * several track types (e.g. `"avc1.640028,mp4a.40.2"`), so we return the first entry whose media
+ * MIME type is an audio type, or `null` if none can be identified.
+ */
+@OptIn(UnstableApi::class)
+private fun Format.toAudioTrackCodec(): String? = codecs
+  ?.split(',')
+  ?.mapNotNull { it.trim().takeUnless(String::isEmpty) }
+  ?.firstOrNull { MimeTypes.isAudio(MimeTypes.getMediaMimeType(it)) }
+
+@OptIn(UnstableApi::class)
+private fun Format.toAudioTrackBitrate(): String? = bitrate
+  .takeIf { it != Format.NO_VALUE && it >= 0 }
+  ?.toString()
+
+/**
+ * Maps this format's channel count to a known channel configuration when possible, falling back to
+ * the raw channel count. `atmos` is intentionally not inferred here since it can't be determined
+ * from a channel count alone.
+ */
+private fun Format.toAudioTrackChannels(): String? = channelCount
+  .takeIf { it != Format.NO_VALUE && it > 0 }
+  ?.let { count ->
+    when (count) {
+      1 -> AudioTrackChangeEvent.AUDIO_TRACK_CHANNELS_MONO
+      2 -> AudioTrackChangeEvent.AUDIO_TRACK_CHANNELS_STEREO
+      6 -> AudioTrackChangeEvent.AUDIO_TRACK_CHANNELS_5_1
+      8 -> AudioTrackChangeEvent.AUDIO_TRACK_CHANNELS_7_1
+      else -> count.toString()
+    }
+  }
 
 private fun String?.toMeaningfulLanguage(): String? = toMeaningfulValue()
   ?.takeUnless { it.equals("und", ignoreCase = true) }

--- a/library-exo/src/test/java/com/mux/stats/sdk/muxstats/AudioTrackChangeReporterTest.kt
+++ b/library-exo/src/test/java/com/mux/stats/sdk/muxstats/AudioTrackChangeReporterTest.kt
@@ -1,0 +1,195 @@
+package com.mux.stats.sdk.muxstats
+
+import androidx.media3.common.Format
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner::class)
+class AudioTrackChangeReporterTest {
+
+  @Test
+  fun `selected audio format reports the audio portion of a codecs string`() {
+    val state = audioFormat(
+      codecs = "avc1.640028,mp4a.40.2",
+      label = "English",
+      language = "en-US",
+      bitrate = 128_000,
+      channelCount = 2,
+    ).toAudioTrackState()
+
+    assertEquals(
+      AudioTrackState(
+        enabled = true,
+        codec = "mp4a.40.2",
+        name = "English",
+        language = "en-us",
+        bitrate = "128000",
+        channels = "stereo",
+      ),
+      state
+    )
+  }
+
+  @Test
+  fun `single audio codec is reported as-is`() {
+    assertEquals("ec-3", audioFormat(codecs = "ec-3").toAudioTrackState().codec)
+  }
+
+  @Test
+  fun `known channel counts are mapped to channel configurations`() {
+    assertEquals("mono", channelsFor(channelCount = 1))
+    assertEquals("stereo", channelsFor(channelCount = 2))
+    assertEquals("5.1", channelsFor(channelCount = 6))
+    assertEquals("7.1", channelsFor(channelCount = 8))
+  }
+
+  @Test
+  fun `unknown channel counts fall back to the raw count`() {
+    assertEquals("3", channelsFor(channelCount = 3))
+  }
+
+  private fun channelsFor(channelCount: Int): String? =
+    audioFormat(codecs = "mp4a.40.2", channelCount = channelCount).toAudioTrackState().channels
+
+  @Test
+  fun `unidentifiable codec and non-meaningful fields are omitted`() {
+    val state = audioFormat(codecs = null, label = " ", language = "und").toAudioTrackState()
+
+    assertEquals(true, state.enabled)
+    assertNull(state.codec)
+    assertNull(state.name)
+    assertNull(state.language)
+    assertNull(state.bitrate)
+    assertNull(state.channels)
+  }
+
+  @Test
+  fun `reporter dispatches initial state, dedupes repeats, and reports changes`() {
+    val reportedStates = mutableListOf<AudioTrackState>()
+    val reporter = AudioTrackChangeReporter { reportedStates += it }
+    val english = audioFormat(codecs = "mp4a.40.2", label = "English", language = "en")
+    val spanish = audioFormat(codecs = "mp4a.40.2", label = "Spanish", language = "es")
+
+    reporter.reportAudioInputFormatChanged(english)
+    reporter.reportAudioInputFormatChanged(english)
+    reporter.reportAudioInputFormatChanged(spanish)
+
+    assertEquals(2, reportedStates.size)
+    assertEquals(
+      AudioTrackState(enabled = true, codec = "mp4a.40.2", name = "English", language = "en"),
+      reportedStates[0]
+    )
+    assertEquals(
+      AudioTrackState(enabled = true, codec = "mp4a.40.2", name = "Spanish", language = "es"),
+      reportedStates[1]
+    )
+  }
+
+  @Test
+  fun `disabling with no prior state reports a single disabled state`() {
+    val reportedStates = mutableListOf<AudioTrackState>()
+    val reporter = AudioTrackChangeReporter { reportedStates += it }
+
+    reporter.reportAudioTrackDisabled()
+
+    assertEquals(listOf(AudioTrackState(enabled = false)), reportedStates)
+  }
+
+  @Test
+  fun `disabling after an enabled track reports a disabled state`() {
+    val reportedStates = mutableListOf<AudioTrackState>()
+    val reporter = AudioTrackChangeReporter { reportedStates += it }
+    val english = audioFormat(codecs = "mp4a.40.2", label = "English", language = "en")
+
+    reporter.reportAudioInputFormatChanged(english)
+    reporter.reportAudioTrackDisabled()
+
+    assertEquals(2, reportedStates.size)
+    assertEquals(
+      AudioTrackState(enabled = true, codec = "mp4a.40.2", name = "English", language = "en"),
+      reportedStates[0]
+    )
+    assertEquals(AudioTrackState(enabled = false), reportedStates[1])
+  }
+
+  @Test
+  fun `repeated disabling dedupes to a single disabled state`() {
+    val reportedStates = mutableListOf<AudioTrackState>()
+    val reporter = AudioTrackChangeReporter { reportedStates += it }
+
+    reporter.reportAudioTrackDisabled()
+    reporter.reportAudioTrackDisabled()
+    reporter.reportAudioTrackDisabled()
+
+    assertEquals(listOf(AudioTrackState(enabled = false)), reportedStates)
+  }
+
+  @Test
+  fun `re-enabling after disabling reports the enabled track again`() {
+    val reportedStates = mutableListOf<AudioTrackState>()
+    val reporter = AudioTrackChangeReporter { reportedStates += it }
+    val english = audioFormat(codecs = "mp4a.40.2", label = "English", language = "en")
+
+    reporter.reportAudioInputFormatChanged(english)
+    reporter.reportAudioTrackDisabled()
+    reporter.reportAudioInputFormatChanged(english)
+
+    assertEquals(3, reportedStates.size)
+    assertEquals(AudioTrackState(enabled = false), reportedStates[1])
+    assertEquals(reportedStates[0], reportedStates[2])
+  }
+
+  @Test
+  fun `reset allows a disabled state to be emitted again for a new view`() {
+    val reportedStates = mutableListOf<AudioTrackState>()
+    val reporter = AudioTrackChangeReporter { reportedStates += it }
+
+    reporter.reportAudioTrackDisabled()
+    reporter.reset()
+    reporter.reportAudioTrackDisabled()
+
+    assertEquals(
+      listOf(AudioTrackState(enabled = false), AudioTrackState(enabled = false)),
+      reportedStates
+    )
+  }
+
+  @Test
+  fun `reporter reset allows same state to be emitted for a new view`() {
+    val reportedStates = mutableListOf<AudioTrackState>()
+    val reporter = AudioTrackChangeReporter { reportedStates += it }
+    val format = audioFormat(codecs = "mp4a.40.2", label = "English", language = "en")
+
+    reporter.reportAudioInputFormatChanged(format)
+    reporter.reset()
+    reporter.reportAudioInputFormatChanged(format)
+
+    assertEquals(2, reportedStates.size)
+    assertEquals(reportedStates[0], reportedStates[1])
+  }
+
+  private fun audioFormat(
+    codecs: String?,
+    label: String? = null,
+    language: String? = null,
+    bitrate: Int = Format.NO_VALUE,
+    channelCount: Int = Format.NO_VALUE,
+  ): Format = Format.Builder()
+    .setSampleMimeType(MimeTypesShim.AUDIO_AAC)
+    .setCodecs(codecs)
+    .setLabel(label)
+    .setLanguage(language)
+    .setAverageBitrate(bitrate)
+    .setChannelCount(channelCount)
+    .build()
+
+  // Keeps the test independent of the @UnstableApi MimeTypes constants.
+  private object MimeTypesShim {
+    const val AUDIO_AAC = "audio/mp4a-latm"
+  }
+}


### PR DESCRIPTION
## Improvements

* Detect Audio track changes and send `audiotrackchange` events (#148)



Co-authored-by: Emily Dixon <edixon@mux.com>
Co-authored-by: GitHub <noreply@github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New playback analytics callbacks on hot ExoPlayer paths could change event volume or miss edge cases; dependency bump on mux core is required for the new API.
> 
> **Overview**
> Adds **audio track change** analytics for Media3/ExoPlayer, mirroring the existing text-track flow: `AudioTrackChangeReporter` dedupes state and calls `muxStats.audioTrackChange` with enabled flag, name, language, codec, bitrate, and channel layout.
> 
> **`onAudioInputFormatChanged`** reports enabled tracks (codec from the audio entry in `CODECS`, bitrate, mono/stereo/5.1/7.1 labels). **`onTracksChanged`** emits disabled when no audio group is selected; ad periods are skipped. State resets on media item transitions.
> 
> Also bumps **`muxCoreJava`** to `8.11.0` (for `AudioTrackChangeEvent`), adds sample DASH/multi-language VOD URLs in the demo app, and adds **`AudioTrackChangeReporterTest`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c3093450490fb28049fa079100f7663d937a912. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->