### PR TITLE
Update Gradle Plugin, Distribution, and Android SDK version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,7 +2,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
   alias(libs.plugins.android.application)
-//  alias(libs.plugins.kotlin.android)
   alias(libs.plugins.kotlin.compose)
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,17 +44,17 @@ android {
   }
 
   sourceSets {
-    getByName("At_latest") { java.srcDir("src/compatFrom1_3/java") }
-    getByName("at_1_0") { java.srcDir("src/compatFrom1_0/java") }
-    getByName("at_1_1") { java.srcDir("src/compatFrom1_0/java") }
-    getByName("at_1_2") { java.srcDir("src/compatFrom1_0/java") }
-    getByName("at_1_3") { java.srcDir("src/compatFrom1_3/java") }
-    getByName("at_1_4") { java.srcDir("src/compatFrom1_3/java") }
-    getByName("at_1_5") { java.srcDir("src/compatFrom1_3/java") }
-    getByName("at_1_6") { java.srcDir("src/compatFrom1_3/java") }
-    getByName("at_1_8") { java.srcDir("src/compatFrom1_3/java") }
-    getByName("at_1_9") { java.srcDir("src/compatFrom1_3/java") }
-    getByName("at_1_10") { java.srcDir("src/compatFrom1_3/java") }
+    getByName("At_latest") { kotlin.directories += "src/compatFrom1_3/java" }
+    getByName("at_1_0") { kotlin.directories += "src/compatFrom1_0/java" }
+    getByName("at_1_1") { kotlin.directories += "src/compatFrom1_0/java" }
+    getByName("at_1_2") { kotlin.directories += "src/compatFrom1_0/java" }
+    getByName("at_1_3") { kotlin.directories += "src/compatFrom1_3/java" }
+    getByName("at_1_4") { kotlin.directories += "src/compatFrom1_3/java" }
+    getByName("at_1_5") { kotlin.directories += "src/compatFrom1_3/java" }
+    getByName("at_1_6") { kotlin.directories += "src/compatFrom1_3/java" }
+    getByName("at_1_8") { kotlin.directories += "src/compatFrom1_3/java" }
+    getByName("at_1_9") { kotlin.directories += "src/compatFrom1_3/java" }
+    getByName("at_1_10") { kotlin.directories += "src/compatFrom1_3/java" }
   }
 
   buildTypes {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
   alias(libs.plugins.android.application)
-  alias(libs.plugins.kotlin.android)
+//  alias(libs.plugins.kotlin.android)
   alias(libs.plugins.kotlin.compose)
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,12 +7,12 @@ plugins {
 
 android {
   namespace = "com.mux.stats.muxdatasdkformedia3"
-  compileSdk = 36
+  compileSdk = 37
 
   defaultConfig {
     applicationId = "com.example.muxdatasdkformedia3"
     //noinspection EditedTargetSdkVersion
-    targetSdk = 36
+    targetSdk = 37
     minSdk = 23
     versionCode = 1
     val commit = providers.exec { commandLine("git", "rev-parse", "--short", "HEAD") }

--- a/automatedtests/build.gradle.kts
+++ b/automatedtests/build.gradle.kts
@@ -64,7 +64,7 @@ android {
   sourceSets {
     getByName("androidTest") {
       // Important, can't get asset file in instrumentation test without this
-      assets.srcDir("src/main/assets")
+      assets.directories += "src/main/assets"
     }
   }
 

--- a/automatedtests/build.gradle.kts
+++ b/automatedtests/build.gradle.kts
@@ -8,13 +8,13 @@ plugins {
 
 android {
   namespace = "com.mux.player.media3"
-  compileSdk = 36
+  compileSdk = 37
 
   defaultConfig {
     applicationId = "com.mux.player.media3"
     minSdk = 23
     //noinspection EditedTargetSdkVersion
-    targetSdk = 36
+    targetSdk = 37
     versionCode = 1
     versionName = "1.0"
     multiDexEnabled = true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.dokka.gradle.DokkaTaskPartial
 plugins {
   alias(libs.plugins.android.application) apply false
   alias(libs.plugins.android.library) apply false
-  alias(libs.plugins.kotlin.android) apply false
+//  alias(libs.plugins.kotlin.android) apply false
   alias(libs.plugins.kotlin.compose)
   alias(libs.plugins.mux.android.distribution) apply false
   alias(libs.plugins.dokka)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,8 +4,8 @@ import org.jetbrains.dokka.gradle.DokkaTaskPartial
 plugins {
   alias(libs.plugins.android.application) apply false
   alias(libs.plugins.android.library) apply false
-//  alias(libs.plugins.kotlin.android) apply false
-  alias(libs.plugins.kotlin.compose)
+  alias(libs.plugins.kotlin.android) apply false
+  alias(libs.plugins.kotlin.compose) apply false
   alias(libs.plugins.mux.android.distribution) apply false
   alias(libs.plugins.dokka)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 # Plugins
-agp = "8.13.2"
+agp = "9.2.1"
 kotlin = "2.2.10"
-muxAndroidDistribution = "1.3.0"
+muxAndroidDistribution = "1.4.0-ng3"
 dokka = "1.6.10"
 
 # Mux core deps

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Plugins
 agp = "9.2.1"
 kotlin = "2.2.10"
-muxAndroidDistribution = "1.4.0-ng3"
+muxAndroidDistribution = "1.4.0-ng4"
 dokka = "1.6.10"
 
 # Mux core deps

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Plugins
 agp = "9.2.1"
 kotlin = "2.2.10"
-muxAndroidDistribution = "1.4.0-ng4"
+muxAndroidDistribution = "1.4.0"
 dokka = "1.6.10"
 
 # Mux core deps

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Nov 18 08:57:39 PST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/library-exo/build.gradle.kts
+++ b/library-exo/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
   alias(libs.plugins.android.library)
-  alias(libs.plugins.kotlin.android)
+//  alias(libs.plugins.kotlin.android)
   alias(libs.plugins.mux.android.distribution)
 }
 
@@ -92,7 +92,8 @@ muxDistribution {
   devVersion(versionFromCommitHash("dev-"))
   releaseVersion(versionFromTag())
   artifactIds { variant ->
-    val media3Variant = variant.productFlavors.first { it.dimension == "media3" }.name
+//    val media3Variant = variant.productFlavors.first { it.dimension == "media3" }.name
+    val media3Variant = variant.productFlavors.first { it.first == "media3" }.second
     if (media3Variant.contains("at_latest", ignoreCase = true)) {
       "data-media3"
     } else {

--- a/library-exo/build.gradle.kts
+++ b/library-exo/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
   alias(libs.plugins.android.library)
-//  alias(libs.plugins.kotlin.android)
   alias(libs.plugins.mux.android.distribution)
 }
 

--- a/library-exo/build.gradle.kts
+++ b/library-exo/build.gradle.kts
@@ -91,7 +91,6 @@ muxDistribution {
   devVersion(versionFromCommitHash("dev-"))
   releaseVersion(versionFromTag())
   artifactIds { variant ->
-//    val media3Variant = variant.productFlavors.first { it.dimension == "media3" }.name
     val media3Variant = variant.productFlavors.first { it.first == "media3" }.second
     if (media3Variant.contains("at_latest", ignoreCase = true)) {
       "data-media3"

--- a/library-exo/build.gradle.kts
+++ b/library-exo/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
   namespace = "com.mux.stats.sdk.muxstats.media3_exo"
-  compileSdk = 36
+  compileSdk = 37
 
   buildFeatures {
     buildConfig = true

--- a/library-ima/build.gradle.kts
+++ b/library-ima/build.gradle.kts
@@ -106,7 +106,6 @@ muxDistribution {
   devVersion(versionFromCommitHash("dev-"))
   releaseVersion(versionFromTag())
   artifactIds { variant ->
-//    val media3Variant = variant.productFlavors.first { it.dimension == "media3" }.name
     val media3Variant = variant.productFlavors.first { it.first == "media3" }.second
     if (media3Variant.contains("at_latest", ignoreCase = true)) {
       "data-media3-ima"

--- a/library-ima/build.gradle.kts
+++ b/library-ima/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
   alias(libs.plugins.android.library)
-//  alias(libs.plugins.kotlin.android)
   alias(libs.plugins.mux.android.distribution)
 }
 

--- a/library-ima/build.gradle.kts
+++ b/library-ima/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
   namespace = "com.mux.stats.sdk.media3_ima"
-  compileSdk = 36
+  compileSdk = 37
 
   buildFeatures {
     buildConfig = true

--- a/library-ima/build.gradle.kts
+++ b/library-ima/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
   alias(libs.plugins.android.library)
-  alias(libs.plugins.kotlin.android)
+//  alias(libs.plugins.kotlin.android)
   alias(libs.plugins.mux.android.distribution)
 }
 
@@ -71,17 +71,17 @@ android {
   }
 
   sourceSets {
-    getByName("at_1_0") { java.srcDir("src/compatFrom_1_0/java") }
-    getByName("at_1_1") { java.srcDir("src/compatFrom_1_0/java") }
-    getByName("at_1_2") { java.srcDir("src/compatFrom_1_0/java") }
-    getByName("at_1_3") { java.srcDir("src/compatFrom_1_0/java") }
-    getByName("at_1_4") { java.srcDir("src/compatFrom_1_0/java") }
-    getByName("at_1_5") { java.srcDir("src/compatFrom_1_0/java") }
-    getByName("at_1_6") { java.srcDir("src/compatFrom_1_0/java") }
-    getByName("at_1_8") { java.srcDir("src/compatFrom_1_0/java") }
-    getByName("at_1_9") { java.srcDir("src/compatFrom_1_9/java") }
-    getByName("at_1_10") { java.srcDir("src/compatFrom_1_9/java") }
-    getByName("At_latest") { java.srcDir("src/compatFrom_1_9/java") }
+    getByName("at_1_0") { java.directories += "src/compatFrom_1_0/java" }
+    getByName("at_1_1") { java.directories += "src/compatFrom_1_0/java" }
+    getByName("at_1_2") { java.directories += "src/compatFrom_1_0/java" }
+    getByName("at_1_3") { java.directories += "src/compatFrom_1_0/java" }
+    getByName("at_1_4") { java.directories += "src/compatFrom_1_0/java" }
+    getByName("at_1_5") { java.directories += "src/compatFrom_1_0/java" }
+    getByName("at_1_6") { java.directories += "src/compatFrom_1_0/java" }
+    getByName("at_1_8") { java.directories += "src/compatFrom_1_0/java" }
+    getByName("at_1_9") { java.directories += "src/compatFrom_1_9/java" }
+    getByName("at_1_10") { java.directories += "src/compatFrom_1_9/java" }
+    getByName("At_latest") { java.directories += "src/compatFrom_1_9/java" }
   }
 
   buildTypes {
@@ -107,7 +107,8 @@ muxDistribution {
   devVersion(versionFromCommitHash("dev-"))
   releaseVersion(versionFromTag())
   artifactIds { variant ->
-    val media3Variant = variant.productFlavors.first { it.dimension == "media3" }.name
+//    val media3Variant = variant.productFlavors.first { it.dimension == "media3" }.name
+    val media3Variant = variant.productFlavors.first { it.first == "media3" }.second
     if (media3Variant.contains("at_latest", ignoreCase = true)) {
       "data-media3-ima"
     } else {

--- a/library-ima/build.gradle.kts
+++ b/library-ima/build.gradle.kts
@@ -71,17 +71,17 @@ android {
   }
 
   sourceSets {
-    getByName("at_1_0") { java.directories += "src/compatFrom_1_0/java" }
-    getByName("at_1_1") { java.directories += "src/compatFrom_1_0/java" }
-    getByName("at_1_2") { java.directories += "src/compatFrom_1_0/java" }
-    getByName("at_1_3") { java.directories += "src/compatFrom_1_0/java" }
-    getByName("at_1_4") { java.directories += "src/compatFrom_1_0/java" }
-    getByName("at_1_5") { java.directories += "src/compatFrom_1_0/java" }
-    getByName("at_1_6") { java.directories += "src/compatFrom_1_0/java" }
-    getByName("at_1_8") { java.directories += "src/compatFrom_1_0/java" }
-    getByName("at_1_9") { java.directories += "src/compatFrom_1_9/java" }
-    getByName("at_1_10") { java.directories += "src/compatFrom_1_9/java" }
-    getByName("At_latest") { java.directories += "src/compatFrom_1_9/java" }
+    getByName("at_1_0") { kotlin.directories += "src/compatFrom_1_0/java" }
+    getByName("at_1_1") { kotlin.directories += "src/compatFrom_1_0/java" }
+    getByName("at_1_2") { kotlin.directories += "src/compatFrom_1_0/java" }
+    getByName("at_1_3") { kotlin.directories += "src/compatFrom_1_0/java" }
+    getByName("at_1_4") { kotlin.directories += "src/compatFrom_1_0/java" }
+    getByName("at_1_5") { kotlin.directories += "src/compatFrom_1_0/java" }
+    getByName("at_1_6") { kotlin.directories += "src/compatFrom_1_0/java" }
+    getByName("at_1_8") { kotlin.directories += "src/compatFrom_1_0/java" }
+    getByName("at_1_9") { kotlin.directories += "src/compatFrom_1_9/java" }
+    getByName("at_1_10") { kotlin.directories += "src/compatFrom_1_9/java" }
+    getByName("At_latest") { kotlin.directories += "src/compatFrom_1_9/java" }
   }
 
   buildTypes {

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
   namespace = "com.mux.stats.sdk.muxstats.media3"
-  compileSdk = 36
+  compileSdk = 37
 
   buildFeatures {
     buildConfig = true

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
   alias(libs.plugins.android.library)
-//  alias(libs.plugins.kotlin.android)
   alias(libs.plugins.mux.android.distribution)
 }
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
   alias(libs.plugins.android.library)
-  alias(libs.plugins.kotlin.android)
+//  alias(libs.plugins.kotlin.android)
   alias(libs.plugins.mux.android.distribution)
 }
 
@@ -91,10 +91,13 @@ muxDistribution {
   devVersion(versionFromCommitHash("dev-"))
   releaseVersion(versionFromTag())
   artifactIds { variant ->
-    val media3Variant = variant.productFlavors.first { it.dimension == "media3" }.name
+    val media3Variant = variant.productFlavors.first { it.first == "media3" }.second
+//    val media3Variant = variant.productFlavors.first { }.name
     if (media3Variant.contains("at_latest", ignoreCase = true)) {
+      println(">>>>>>media3Variant: $media3Variant")
       "data-media3-custom"
     } else {
+      println(">>>>>media3Variant: $media3Variant")
       "data-media3-custom-$media3Variant"
     }
   }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -91,12 +91,9 @@ muxDistribution {
   releaseVersion(versionFromTag())
   artifactIds { variant ->
     val media3Variant = variant.productFlavors.first { it.first == "media3" }.second
-//    val media3Variant = variant.productFlavors.first { }.name
     if (media3Variant.contains("at_latest", ignoreCase = true)) {
-      println(">>>>>>media3Variant: $media3Variant")
       "data-media3-custom"
     } else {
-      println(">>>>>media3Variant: $media3Variant")
       "data-media3-custom-$media3Variant"
     }
   }


### PR DESCRIPTION
These all have to be done at once, so here they are

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide build-tooling and publishing-config changes can break CI or artifact naming without affecting app runtime logic; verify full flavor matrix builds and release publishing.
> 
> **Overview**
> Bumps the Android build toolchain in one pass: **AGP 8.13.2 → 9.2.1**, **Gradle 8.13 → 9.5.1**, **Mux Android distribution plugin 1.3.0 → 1.4.0**, and **compileSdk / targetSdk 36 → 37** on `app`, `automatedtests`, and the library modules.
> 
> Adapts scripts to AGP 9 APIs: flavor compat dirs move from `java.srcDir(...)` to **`kotlin.directories +=`**, instrumentation test assets use **`assets.directories +=`**, and **`muxDistribution` `artifactIds`** read product flavors as **`Pair` (`first` / `second`)** instead of `.dimension` / `.name`. **`org.jetbrains.kotlin.android`** is dropped from modules that only needed it alongside the Android plugin; the root **`kotlin.compose`** plugin is declared with **`apply false`** so it is not applied at the root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4219700544e878d4f705c127b3ba2a077fccfb3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->