### PR TITLE
NAT-467: Start watching playhead when registering late

### DIFF
--- a/library/src/main/java/com/mux/stats/sdk/muxstats/PlayerUtils.kt
+++ b/library/src/main/java/com/mux/stats/sdk/muxstats/PlayerUtils.kt
@@ -54,6 +54,10 @@ fun catchUpPlayState(player: Player, collector: MuxStateCollector) {
   if (player.playbackState != Player.STATE_IDLE) {
     collector.handleExoPlaybackState(player.playbackState, player.playWhenReady)
   }
+  if (!player.currentTracks.isEmpty) {
+    // If caller registers after tracks loaded, we never get the playhead, some metrics will break
+    collector.watchPlayerPos(player) // any old position-watchers will be stopped and cleaned up
+  }
 }
 
 @JvmSynthetic


### PR DESCRIPTION
`catchUpPlayState` is called when a player is bound to the monitor, or whenever we re-enable a previously-disabled monitor

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small additive path in existing late-registration catch-up logic; reuses `watchPlayerPos`, which replaces prior watchers.
> 
> **Overview**
> **Late Mux registration** now starts playhead polling when tracks are already available, matching what normally happens on `onTracksChanged`.
> 
> `catchUpPlayState` calls `collector.watchPlayerPos(player)` if `player.currentTracks` is non-empty, so integrations that enable Mux after `prepare()` / track load still get periodic position updates instead of missing the callback and breaking playhead-dependent metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f781eaa60a82ef8c9e2b05900f3d7a05918aea02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->