### PR TITLE
Update mux-stats-sdk-java to 8.12.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ dokka = "1.6.10"
 
 # Mux core deps
 muxCoreAndroid = "1.7.2"
-muxCoreJava = "8.11.0"
+muxCoreJava = "8.12.0"
 
 # media3 per-variant pins.
 #


### PR DESCRIPTION
Update mux-stats-sdk-java to 8.12.0

Bumps `muxCoreJava` in `gradle/libs.versions.toml` from `8.11.0` to `8.12.0`.

## mux-stats-sdk-java v8.12.0 release notes

### Added
- Added `view_playing_time` (`getViewPlayingTime` / `setViewPlayingTime`).

### Deprecated
- Deprecated `view_content_playback_time` (`getViewContentPlaybackTime` / `setViewContentPlaybackTime`) in favor of `view_playing_time`. The deprecated accessors remain as shims backed by the same value, so existing callers keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only patch bump with backward-compatible API shims; no application code changes in this PR.
> 
> **Overview**
> Bumps the **`muxCoreJava`** version pin in `gradle/libs.versions.toml` from **8.11.0** to **8.12.0**, which updates the resolved **`com.mux:stats.muxcore`** artifact for anything that uses the **`mux-core-java`** catalog entry (including **`api`** on **`:library`**).
> 
> Upstream **8.12.0** adds **`view_playing_time`** and deprecates **`view_content_playback_time`** in favor of that field; the old accessors remain as shims, so this repo needs no source changes for the rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1717378fcc1cdd9a8a096e838960422a0b4a80b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->