### PR TITLE
NAT-495: Non-ExoPlayer Players should send pause and playing normally

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,6 +56,7 @@
             </intent-filter>
         </activity>
         <activity android:name=".examples.basic.BasicPlayerActivity" />
+        <activity android:name=".examples.basic.NonExoPlayerActivity" />
 
     </application>
 

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/Constants.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/Constants.kt
@@ -1,7 +1,7 @@
 package com.mux.stats.muxdatasdkformedia3
 
 object Constants {
-  const val MUX_DATA_ENV_KEY = "rhhn9fph0nog346n4tqb6bqda"
+  const val MUX_DATA_ENV_KEY = "YOUR MUX DATA ENV KEY HERE"
   const val VOD_TEST_URL_STEVE = "http://qthttp.apple.com.edgesuite.net/1010qwoeiuryfg/sl.m3u8"
   const val VOD_TEST_URL_TEARS_OF_STEEL = "https://stream.mux.com/u02xH9SB1ZZNNjPiQp4l6mhzBKJ101uExYx4LU02J5Xm88.m3u8"
   const val VOD_TEST_URL_BIG_BUCK_BUNNY = "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8"

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/Constants.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/Constants.kt
@@ -1,7 +1,7 @@
 package com.mux.stats.muxdatasdkformedia3
 
 object Constants {
-  const val MUX_DATA_ENV_KEY = "YOUR MUX DATA ENV KEY HERE"
+  const val MUX_DATA_ENV_KEY = "rhhn9fph0nog346n4tqb6bqda"
   const val VOD_TEST_URL_STEVE = "http://qthttp.apple.com.edgesuite.net/1010qwoeiuryfg/sl.m3u8"
   const val VOD_TEST_URL_TEARS_OF_STEEL = "https://stream.mux.com/u02xH9SB1ZZNNjPiQp4l6mhzBKJ101uExYx4LU02J5Xm88.m3u8"
   const val VOD_TEST_URL_BIG_BUCK_BUNNY = "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8"

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/MainActivity.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/MainActivity.kt
@@ -17,6 +17,7 @@ import com.mux.stats.muxdatasdkformedia3.databinding.ActivityMainBinding
 import com.mux.stats.muxdatasdkformedia3.databinding.ListitemExampleBinding
 import com.mux.stats.muxdatasdkformedia3.examples.basic.BasicPlayerActivity
 import com.mux.stats.muxdatasdkformedia3.examples.basic.ComposeUiExampleActivity
+import com.mux.stats.muxdatasdkformedia3.examples.basic.NonExoPlayerActivity
 import com.mux.stats.muxdatasdkformedia3.examples.basic.PlayerReuseActivity
 import com.mux.stats.muxdatasdkformedia3.examples.ima.ImaClientAdsActivity
 import com.mux.stats.muxdatasdkformedia3.examples.ima.ImaServerAdsActivity
@@ -77,6 +78,10 @@ class MainActivity : AppCompatActivity() {
       title = "Reusing a Player for multiple MediaItems",
       destination = Intent(this, PlayerReuseActivity::class.java),
     ),
+    Example(
+      title = "Non-ExoPlayer media3 Player",
+      destination = Intent(this, NonExoPlayerActivity::class.java)
+    )
     // TODO: post-beta, add APIs for talking to a `MediaSessionService`
 //    Example(
 //      title = "Background playback",

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/basic/NonExoPlayerActivity.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/basic/NonExoPlayerActivity.kt
@@ -37,7 +37,7 @@ class NonExoPlayerActivity : AppCompatActivity() {
 
   private lateinit var view: ActivityPlayerBinding
   private var player: Player? = null
-  private var muxStats: MuxStatsSdkMedia3<*>? = null
+  private var muxStats: MuxStatsSdkMedia3<out Player>? = null
 
   @OptIn(UnstableApi::class)
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -101,7 +101,7 @@ class NonExoPlayerActivity : AppCompatActivity() {
     muxStats?.release()
   }
 
-  private fun monitorPlayer(player: Player): MuxStatsSdkMedia3<*> {
+  private fun monitorPlayer(player: Player): MuxStatsSdkMedia3<out Player> {
     // You can add your own data to a View, which will override any data we collect
     val customerData = CustomerData(
       CustomerPlayerData().apply { },

--- a/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/basic/NonExoPlayerActivity.kt
+++ b/app/src/main/java/com/mux/stats/muxdatasdkformedia3/examples/basic/NonExoPlayerActivity.kt
@@ -1,0 +1,150 @@
+package com.mux.stats.muxdatasdkformedia3.examples.basic
+
+import android.os.Bundle
+import android.util.Log
+import android.widget.Toast
+import androidx.annotation.OptIn
+import androidx.appcompat.app.AppCompatActivity
+import androidx.media3.common.ForwardingPlayer
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.PlayerView.KEEP_SCREEN_ON
+import androidx.media3.ui.PlayerView.SHOW_BUFFERING_WHEN_PLAYING
+import com.mux.stats.muxdatasdkformedia3.Constants
+import com.mux.stats.muxdatasdkformedia3.databinding.ActivityPlayerBinding
+import com.mux.stats.muxdatasdkformedia3.toMediaItem
+import com.mux.stats.sdk.core.model.CustomData
+import com.mux.stats.sdk.core.model.CustomerData
+import com.mux.stats.sdk.core.model.CustomerPlayerData
+import com.mux.stats.sdk.core.model.CustomerVideoData
+import com.mux.stats.sdk.core.model.CustomerViewData
+import com.mux.stats.sdk.core.util.MuxLogger
+import com.mux.stats.sdk.muxstats.MuxDataSdk
+import com.mux.stats.sdk.muxstats.MuxStatsSdkMedia3
+import com.mux.stats.sdk.muxstats.monitorWithMuxData
+
+/**
+ * Example that exercises the non-exoplayer [com.mux.stats.sdk.muxstats.BaseMedia3Binding]
+ *
+ * Wraps an ExoPlayer in a ForwardingPlayer to hide the player type
+ */
+@OptIn(UnstableApi::class) // for ForwardingPlayer
+class NonExoPlayerActivity : AppCompatActivity() {
+
+  private lateinit var view: ActivityPlayerBinding
+  private var player: Player? = null
+  private var muxStats: MuxStatsSdkMedia3<*>? = null
+
+  @OptIn(UnstableApi::class)
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    view = ActivityPlayerBinding.inflate(layoutInflater)
+    setContentView(view.root)
+
+    view.playerView.apply {
+      setShowBuffering(SHOW_BUFFERING_WHEN_PLAYING)
+      setShowSubtitleButton(true)
+    }
+    window.addFlags(KEEP_SCREEN_ON)
+  }
+
+  override fun onResume() {
+    super.onResume()
+    startPlaying(
+      intent.getStringExtra(EXTRA_URL) ?: Constants.VOD_TEST_URL_TEARS_OF_STEEL
+    )
+  }
+
+  override fun onPause() {
+    stopPlaying()
+    super.onPause()
+  }
+
+  private fun startPlaying(mediaUrl: String) {
+    stopPlaying()
+
+    player = createPlayer().also { newPlayer ->
+      newPlayer.trackSelectionParameters = newPlayer.trackSelectionParameters
+        .buildUpon()
+        .setPreferredTextLanguage("en")
+        .build()
+
+      muxStats = monitorPlayer(newPlayer)
+
+      view.playerView.player = newPlayer
+      newPlayer.setMediaItem(createMediaItem(mediaUrl))
+      newPlayer.prepare()
+      newPlayer.playWhenReady = true
+    }
+  }
+
+  private fun createMediaItem(mediaUrl: String): MediaItem {
+    return mediaUrl.toMediaItem().buildUpon()
+      .setMediaMetadata(
+        MediaMetadata.Builder()
+          .setTitle("Sample app, BasicPlayerActivity")
+          .setDescription("A Basic test video")
+          .build()
+      ).build()
+  }
+
+  private fun stopPlaying() {
+    player?.let { oldPlayer ->
+      oldPlayer.stop()
+      oldPlayer.release()
+    }
+    // Make sure to release() your muxStats whenever the user is done with the player
+    muxStats?.release()
+  }
+
+  private fun monitorPlayer(player: Player): MuxStatsSdkMedia3<*> {
+    // You can add your own data to a View, which will override any data we collect
+    val customerData = CustomerData(
+      CustomerPlayerData().apply { },
+      CustomerVideoData().apply {
+        videoId = "A Custom ID"
+        videoTitle = "Non-ExoPlayer Monitor"
+      },
+      CustomerViewData().apply {
+        // User-readable client application name
+        viewClientApplicationName = "My Custom Application Name"
+        // User-readable client application version
+        viewClientApplicationVersion = "My Custom Application Version"
+      },
+      CustomData().apply {
+        customData1 = "Arbitrary custom dimension value"
+      },
+    )
+
+    MuxLogger.setAllowLogcat(true)
+    return player.monitorWithMuxData(
+      context = this,
+      envKey = Constants.MUX_DATA_ENV_KEY,
+      customerData = customerData,
+      playerView = view.playerView,
+      logLevel = MuxDataSdk.LogcatLevel.DEBUG,
+    )
+  }
+
+  private fun createPlayer(): Player {
+    val exoPlayer = ExoPlayer.Builder(this)
+      .build().apply {
+        addListener(object : Player.Listener {
+          override fun onPlayerError(error: PlaybackException) {
+            Log.e(javaClass.simpleName, "player error!", error)
+            Toast.makeText(this@NonExoPlayerActivity, error.localizedMessage, Toast.LENGTH_SHORT)
+              .show()
+          }
+        })
+      }
+    return ForwardingPlayer(exoPlayer)
+  }
+
+  companion object {
+    const val EXTRA_URL: String = "com.mux.video.url"
+  }
+}

--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/PlayerExt.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/PlayerExt.kt
@@ -27,7 +27,7 @@ fun Player.monitorWithMuxData(
   playerView: View? = null,
   customOptions: CustomOptions? = null,
   logLevel: MuxDataSdk.LogcatLevel = MuxDataSdk.LogcatLevel.NONE,
-): MuxStatsSdkMedia3<*> {
+): MuxStatsSdkMedia3<out Player> {
   return if (this is ExoPlayer) {
     MuxStatsSdkMedia3(
       context = context,

--- a/library/src/main/java/com/mux/stats/sdk/muxstats/BaseMedia3Binding.kt
+++ b/library/src/main/java/com/mux/stats/sdk/muxstats/BaseMedia3Binding.kt
@@ -44,6 +44,10 @@ private class MuxPlayerListener(player: Player, val collector: MuxStateCollector
     player?.let { collector.handleExoPlaybackState(playbackState, it.playWhenReady) }
   }
 
+  override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
+    player?.let { collector.handlePlayWhenReady(playWhenReady, it.playbackState) }
+  }
+
   override fun onPositionDiscontinuity(
     oldPosition: Player.PositionInfo,
     newPosition: Player.PositionInfo,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes event collection in the generic Media3 binding path, which can affect Mux view metrics for non-ExoPlayer integrations; scope is limited and aligned with existing ExoPlayer handling patterns.
> 
> **Overview**
> Fixes **Mux analytics play/pause** for generic Media3 `Player` integrations (non-`ExoPlayer` binding) by listening for **`onPlayWhenReadyChanged`** in `BaseMedia3Binding` and forwarding to `handlePlayWhenReady`, so pause and playing events are not missed when callback ordering differs from ExoPlayer-only paths.
> 
> The sample app adds **`NonExoPlayerActivity`**, which wraps `ExoPlayer` in a **`ForwardingPlayer`** and uses `monitorWithMuxData`, plus a launcher entry in `MainActivity`. **`Player.monitorWithMuxData`** now returns **`MuxStatsSdkMedia3<out Player>`** instead of a star-projected type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcd332621e546b50b49885adfba6058890e01d1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->