### PR TITLE
Tighten type bounds of the generic monitorWithMuxData to <out Player> from <*>

### DIFF
--- a/library-exo/src/main/java/com/mux/stats/sdk/muxstats/PlayerExt.kt
+++ b/library-exo/src/main/java/com/mux/stats/sdk/muxstats/PlayerExt.kt
@@ -27,7 +27,7 @@ fun Player.monitorWithMuxData(
   playerView: View? = null,
   customOptions: CustomOptions? = null,
   logLevel: MuxDataSdk.LogcatLevel = MuxDataSdk.LogcatLevel.NONE,
-): MuxStatsSdkMedia3<*> {
+): MuxStatsSdkMedia3<out Player> {
   return if (this is ExoPlayer) {
     MuxStatsSdkMedia3(
       context = context,


### PR DESCRIPTION
This is not a breaking change, as existing callers could only refer to the return value as `<*>`, and `<out Player>` is assignable to `<*>`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line Kotlin API signature change with no logic changes; intended to be non-breaking for existing callers.
> 
> **Overview**
> Narrows the declared return type of `Player.monitorWithMuxData` in **PlayerExt.kt** from `MuxStatsSdkMedia3<*>` to `MuxStatsSdkMedia3<out Player>`.
> 
> Callers get a more precise generic bound (the SDK is tied to a `Player` subtype) without changing implementation or runtime behavior. The PR notes this remains source-compatible because `out Player` is still usable wherever the previous star projection was accepted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d404f884609a96fad702850b42e12af8c579c29a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->