### PR TITLE
Add support for media3 v1.11.*

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,6 +40,7 @@ android {
     create("at_1_8") { dimension = "media3" }
     create("at_1_9") { dimension = "media3" }
     create("at_1_10") { dimension = "media3" }
+    create("at_1_11") { dimension = "media3" }
   }
 
   sourceSets {
@@ -54,6 +55,7 @@ android {
     getByName("at_1_8") { kotlin.directories += "src/compatFrom1_3/java" }
     getByName("at_1_9") { kotlin.directories += "src/compatFrom1_3/java" }
     getByName("at_1_10") { kotlin.directories += "src/compatFrom1_3/java" }
+    getByName("at_1_11") { kotlin.directories += "src/compatFrom1_3/java" }
   }
 
   buildTypes {
@@ -123,6 +125,7 @@ dependencies {
   "at_1_9Implementation"(libs.bundles.media3.app.at19)
   //noinspection GradleDependency
   "at_1_10Implementation"(libs.bundles.media3.app.at110)
+  "at_1_11Implementation"(libs.bundles.media3.app.at111)
   "At_latestImplementation"(libs.bundles.media3.app.atLatest)
 
   implementation(libs.androidx.core.ktx)

--- a/automatedtests/build.gradle.kts
+++ b/automatedtests/build.gradle.kts
@@ -37,6 +37,7 @@ android {
     create("at_1_8") { dimension = "media3" }
     create("at_1_9") { dimension = "media3" }
     create("at_1_10") { dimension = "media3" }
+    create("at_1_11") { dimension = "media3" }
   }
 
   buildFeatures {
@@ -105,6 +106,7 @@ dependencies {
   "at_1_9Implementation"(libs.bundles.media3.app.at19)
   //noinspection GradleDependency
   "at_1_10Implementation"(libs.bundles.media3.app.at110)
+  "at_1_11Implementation"(libs.bundles.media3.app.at111)
   "At_latestImplementation"(libs.bundles.media3.app.atLatest)
 
   androidTestImplementation(libs.androidx.test.runner)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,8 @@ media3-at16 = "1.6.0"
 media3-at18 = "1.8.0"
 media3-at19 = "1.9.0"
 media3-at110 = "1.10.0"
-media3-atLatest = "1.10.0"
+media3-at111 = "1.10.0"
+media3-atLatest = "1.11.0"
 
 # AndroidX / Compose / Material
 androidx-coreKtx = "1.17.0"
@@ -85,6 +86,7 @@ media3-common-at16 = { group = "androidx.media3", name = "media3-common", versio
 media3-common-at18 = { group = "androidx.media3", name = "media3-common", version.ref = "media3-at18" }
 media3-common-at19 = { group = "androidx.media3", name = "media3-common", version.ref = "media3-at19" }
 media3-common-at110 = { group = "androidx.media3", name = "media3-common", version.ref = "media3-at110" }
+media3-common-at111 = { group = "androidx.media3", name = "media3-common", version.ref = "media3-at111" }
 media3-common-atLatest = { group = "androidx.media3", name = "media3-common", version.ref = "media3-atLatest" }
 
 # --- media3-exoplayer (:library-exo uses bare alias; :library-ima at_1_1 + :app + :automatedtests use `app` variants) ---
@@ -100,6 +102,7 @@ media3-exoplayer-at16 = { group = "androidx.media3", name = "media3-exoplayer", 
 media3-exoplayer-at18 = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3-at18" }
 media3-exoplayer-at19 = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3-at19" }
 media3-exoplayer-at110 = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3-at110" }
+media3-exoplayer-at111 = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3-at111" }
 media3-exoplayer-atLatest = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3-atLatest" }
 
 # --- media3-exoplayer-hls (:library-exo bare; :app + :automatedtests use `app` variants) ---
@@ -115,6 +118,7 @@ media3-exoplayerHls-at16 = { group = "androidx.media3", name = "media3-exoplayer
 media3-exoplayerHls-at18 = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3-at18" }
 media3-exoplayerHls-at19 = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3-at19" }
 media3-exoplayerHls-at110 = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3-at110" }
+media3-exoplayerHls-at111 = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3-at111" }
 media3-exoplayerHls-atLatest = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3-atLatest" }
 
 # --- media3-exoplayer-ima (:library-ima bare for at_1_4, `app` for at_1_1; :app + :automatedtests `app`) ---
@@ -129,6 +133,7 @@ media3-exoplayerIma-at16 = { group = "androidx.media3", name = "media3-exoplayer
 media3-exoplayerIma-at18 = { group = "androidx.media3", name = "media3-exoplayer-ima", version.ref = "media3-at18" }
 media3-exoplayerIma-at19 = { group = "androidx.media3", name = "media3-exoplayer-ima", version.ref = "media3-at19" }
 media3-exoplayerIma-at110 = { group = "androidx.media3", name = "media3-exoplayer-ima", version.ref = "media3-at110" }
+media3-exoplayerIma-at111 = { group = "androidx.media3", name = "media3-exoplayer-ima", version.ref = "media3-at111" }
 media3-exoplayerIma-atLatest = { group = "androidx.media3", name = "media3-exoplayer-ima", version.ref = "media3-atLatest" }
 
 # --- media3-exoplayer-dash (:app + :automatedtests; always the `app` patch where applicable) ---
@@ -142,6 +147,7 @@ media3-exoplayerDash-at16 = { group = "androidx.media3", name = "media3-exoplaye
 media3-exoplayerDash-at18 = { group = "androidx.media3", name = "media3-exoplayer-dash", version.ref = "media3-at18" }
 media3-exoplayerDash-at19 = { group = "androidx.media3", name = "media3-exoplayer-dash", version.ref = "media3-at19" }
 media3-exoplayerDash-at110 = { group = "androidx.media3", name = "media3-exoplayer-dash", version.ref = "media3-at110" }
+media3-exoplayerDash-at111 = { group = "androidx.media3", name = "media3-exoplayer-dash", version.ref = "media3-at111" }
 media3-exoplayerDash-atLatest = { group = "androidx.media3", name = "media3-exoplayer-dash", version.ref = "media3-atLatest" }
 
 # --- media3-exoplayer-rtsp (:app + :automatedtests; always the `app` patch where applicable) ---
@@ -155,6 +161,7 @@ media3-exoplayerRtsp-at16 = { group = "androidx.media3", name = "media3-exoplaye
 media3-exoplayerRtsp-at18 = { group = "androidx.media3", name = "media3-exoplayer-rtsp", version.ref = "media3-at18" }
 media3-exoplayerRtsp-at19 = { group = "androidx.media3", name = "media3-exoplayer-rtsp", version.ref = "media3-at19" }
 media3-exoplayerRtsp-at110 = { group = "androidx.media3", name = "media3-exoplayer-rtsp", version.ref = "media3-at110" }
+media3-exoplayerRtsp-at111 = { group = "androidx.media3", name = "media3-exoplayer-rtsp", version.ref = "media3-at111" }
 media3-exoplayerRtsp-atLatest = { group = "androidx.media3", name = "media3-exoplayer-rtsp", version.ref = "media3-atLatest" }
 
 # --- media3-session (:app + :automatedtests; always the `app` patch where applicable) ---
@@ -168,6 +175,7 @@ media3-session-at16 = { group = "androidx.media3", name = "media3-session", vers
 media3-session-at18 = { group = "androidx.media3", name = "media3-session", version.ref = "media3-at18" }
 media3-session-at19 = { group = "androidx.media3", name = "media3-session", version.ref = "media3-at19" }
 media3-session-at110 = { group = "androidx.media3", name = "media3-session", version.ref = "media3-at110" }
+media3-session-at111 = { group = "androidx.media3", name = "media3-session", version.ref = "media3-at111" }
 media3-session-atLatest = { group = "androidx.media3", name = "media3-session", version.ref = "media3-atLatest" }
 
 # --- media3-ui (:app + :automatedtests; always the `app` patch where applicable) ---
@@ -181,6 +189,7 @@ media3-ui-at16 = { group = "androidx.media3", name = "media3-ui", version.ref = 
 media3-ui-at18 = { group = "androidx.media3", name = "media3-ui", version.ref = "media3-at18" }
 media3-ui-at19 = { group = "androidx.media3", name = "media3-ui", version.ref = "media3-at19" }
 media3-ui-at110 = { group = "androidx.media3", name = "media3-ui", version.ref = "media3-at110" }
+media3-ui-at111 = { group = "androidx.media3", name = "media3-ui", version.ref = "media3-at111" }
 media3-ui-atLatest = { group = "androidx.media3", name = "media3-ui", version.ref = "media3-atLatest" }
 
 # --- AndroidX, Material, Compose ---
@@ -312,6 +321,15 @@ media3-app-at110 = [
   "media3-exoplayerDash-at110",
   "media3-exoplayerHls-at110",
   "media3-exoplayerRtsp-at110",
+]
+media3-app-at111 = [
+  "media3-exoplayer-at111",
+  "media3-session-at111",
+  "media3-ui-at111",
+  "media3-exoplayerIma-at111",
+  "media3-exoplayerDash-at111",
+  "media3-exoplayerHls-at111",
+  "media3-exoplayerRtsp-at111",
 ]
 media3-app-atLatest = [
   "media3-exoplayer-atLatest",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ media3-at16 = "1.6.0"
 media3-at18 = "1.8.0"
 media3-at19 = "1.9.0"
 media3-at110 = "1.10.0"
-media3-at111 = "1.10.0"
+media3-at111 = "1.11.0"
 media3-atLatest = "1.11.0"
 
 # AndroidX / Compose / Material

--- a/library-exo/build.gradle.kts
+++ b/library-exo/build.gradle.kts
@@ -190,12 +190,6 @@ dependencies {
   //noinspection GradleDependency
   "at_1_10CompileOnly"(libs.media3.exoplayerHls.at110)
 
-
-  //noinspection GradleDependency
-  "at_1_10Api"(libs.media3.exoplayer.at110)
-  //noinspection GradleDependency
-  "at_1_10CompileOnly"(libs.media3.exoplayerHls.at110)
-
   //noinspection GradleDependency
   "at_1_11Api"(libs.media3.exoplayer.at111)
   //noinspection GradleDependency

--- a/library-exo/build.gradle.kts
+++ b/library-exo/build.gradle.kts
@@ -67,6 +67,9 @@ android {
     create("at_1_10") {
       dimension = "media3"
     }
+    create("at_1_11") {
+      dimension = "media3"
+    }
   }
 
   buildTypes {
@@ -186,6 +189,17 @@ dependencies {
   "at_1_10Api"(libs.media3.exoplayer.at110)
   //noinspection GradleDependency
   "at_1_10CompileOnly"(libs.media3.exoplayerHls.at110)
+
+
+  //noinspection GradleDependency
+  "at_1_10Api"(libs.media3.exoplayer.at110)
+  //noinspection GradleDependency
+  "at_1_10CompileOnly"(libs.media3.exoplayerHls.at110)
+
+  //noinspection GradleDependency
+  "at_1_11Api"(libs.media3.exoplayer.at111)
+  //noinspection GradleDependency
+  "at_1_11CompileOnly"(libs.media3.exoplayerHls.at111)
 
   //noinspection GradleDependency
   "At_latestApi"(libs.media3.exoplayer.atLatest)

--- a/library-ima/build.gradle.kts
+++ b/library-ima/build.gradle.kts
@@ -67,6 +67,9 @@ android {
     create("at_1_10") {
       dimension = "media3"
     }
+    create("at_1_11") {
+      dimension = "media3"
+    }
   }
 
   sourceSets {
@@ -80,6 +83,7 @@ android {
     getByName("at_1_8") { kotlin.directories += "src/compatFrom_1_0/java" }
     getByName("at_1_9") { kotlin.directories += "src/compatFrom_1_9/java" }
     getByName("at_1_10") { kotlin.directories += "src/compatFrom_1_9/java" }
+    getByName("at_1_11") { kotlin.directories += "src/compatFrom_1_9/java" }
     getByName("At_latest") { kotlin.directories += "src/compatFrom_1_9/java" }
   }
 
@@ -194,6 +198,10 @@ dependencies {
   "at_1_10Api"(libs.media3.exoplayer.at110)
   //noinspection GradleDependency
   "at_1_10Api"(libs.media3.exoplayerIma.at110)
+  //noinspection GradleDependency
+  "at_1_11Api"(libs.media3.exoplayer.at111)
+  //noinspection GradleDependency
+  "at_1_11Api"(libs.media3.exoplayerIma.at111)
 
   //noinspection GradleDependency
   "At_latestApi"(libs.media3.exoplayer.atLatest)

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -66,6 +66,9 @@ android {
     create("at_1_10") {
       dimension = "media3"
     }
+    create("at_1_11") {
+      dimension = "media3"
+    }
   }
 
   buildTypes {
@@ -157,6 +160,7 @@ dependencies {
   "at_1_9Api"(libs.media3.common.at19)
   //noinspection GradleDependency // benefit from optimistic matching
   "at_1_10Api"(libs.media3.common.at110)
+  "at_1_11Api"(libs.media3.common.at111)
   //noinspection GradleDependency // benefit from optimistic matching
   "At_latestApi"(libs.media3.common.atLatest)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Gradle-only version-matrix expansion mirroring prior Media3 releases; no runtime logic changes in the diff.
> 
> **Overview**
> Adds **AndroidX Media3 1.11.0** to the existing per-version Gradle flavor matrix so the SDK can be built and tested against that line.
> 
> In `gradle/libs.versions.toml`, introduces `media3-at111` (**1.11.0**), bumps **`media3-atLatest`** from 1.10.0 to **1.11.0**, and wires matching library aliases plus a `media3-app-at111` bundle (exoplayer, session, UI, IMA, DASH, HLS, RTSP).
> 
> **`app`**, **`automatedtests`**, **`library`**, **`library-exo`**, and **`library-ima`** each gain an **`at_1_11`** product flavor with the same dependency/source-set wiring as **`at_1_10`** (e.g. `compatFrom1_3` for app, `compatFrom_1_9` for IMA). No application or library Kotlin/Java source changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8977cbb93a098970a3312d16053833753f2e63f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->